### PR TITLE
Major changes. Release 2.0.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,48 @@
+name: Bug Report
+description: Something isn't working as documented
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please check existing issues before submitting.
+
+  - type: input
+    id: version
+    attributes:
+      label: Library version
+      placeholder: "e.g. 2.0.0"
+    validations:
+      required: true
+
+  - type: input
+    id: dotnet
+    attributes:
+      label: .NET version
+      placeholder: "e.g. .NET 10"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect?
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Minimal reproduction
+      description: The smallest code sample that demonstrates the issue.
+      render: csharp
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or how-to
+    url: https://github.com/friend-to-net-web-developers/micro-utilities/discussions
+    about: Not a bug or feature request? Ask here.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,28 @@
+name: Feature Request
+description: Suggest an addition or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Feature requests are welcome. Please be as specific as possible.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the use case. What are you trying to do that the library doesn't currently support?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed API or behaviour
+      description: If you have a specific API in mind, show it here. Pseudocode is fine.
+      render: csharp
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives you've considered

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    target-branch: "main"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    target-branch: "main"

--- a/.github/workflows/dotnet-test-and-deploy-on-push.yml
+++ b/.github/workflows/dotnet-test-and-deploy-on-push.yml
@@ -14,8 +14,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            8.0.x
-            9.0.x
             10.0.x
       - name: Restore dependencies
         run: dotnet restore

--- a/.github/workflows/dotnet-test-on-pr-net.yml
+++ b/.github/workflows/dotnet-test-on-pr-net.yml
@@ -23,8 +23,6 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |
-          8.0.x
-          9.0.x
           10.0.x
     - name: Restore dependencies
       run: dotnet restore

--- a/FriendToNetWebDevelopers.MicroUtilities.Test/FriendToNetWebDevelopers.MicroUtilities.Test.csproj
+++ b/FriendToNetWebDevelopers.MicroUtilities.Test/FriendToNetWebDevelopers.MicroUtilities.Test.csproj
@@ -11,11 +11,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0"/>
-        <PackageReference Include="NUnit" Version="3.13.3"/>
-        <PackageReference Include="NUnit3TestAdapter" Version="4.2.1"/>
-        <PackageReference Include="NUnit.Analyzers" Version="3.6.1"/>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+        <PackageReference Include="NUnit" Version="4.5.1" />
+        <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+        <PackageReference Include="NUnit.Analyzers" Version="4.12.0">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="8.0.1">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/FriendToNetWebDevelopers.MicroUtilities.Test/FriendToNetWebDevelopers.MicroUtilities.Test.csproj
+++ b/FriendToNetWebDevelopers.MicroUtilities.Test/FriendToNetWebDevelopers.MicroUtilities.Test.csproj
@@ -7,7 +7,7 @@
 
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
-        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+        <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/FriendToNetWebDevelopers.MicroUtilities.Test/YoutubeTests.cs
+++ b/FriendToNetWebDevelopers.MicroUtilities.Test/YoutubeTests.cs
@@ -29,11 +29,11 @@ public class YoutubeTests
         var defaultOkayResponse = client.GetAsync(new Uri(defaultOkay)).Result;
         Assert.That(defaultOkayResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK)); 
         
-        var hqDefaultOkay = Utilities.Youtube.GetYoutubeThumbnail(ValidYoutubeId, YoutubeThumbnailEnum.HqDefault);
+        var hqDefaultOkay = Utilities.Youtube.GetYoutubeThumbnail(ValidYoutubeId, YoutubeThumbnail.HqDefault);
         var hqDefaultOkayResponse = client.GetAsync(new Uri(hqDefaultOkay)).Result;
         Assert.That(hqDefaultOkayResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK));
         
-        var maxResDefaultOkay = Utilities.Youtube.GetYoutubeThumbnail(ValidYoutubeId, YoutubeThumbnailEnum.MaxResDefault);
+        var maxResDefaultOkay = Utilities.Youtube.GetYoutubeThumbnail(ValidYoutubeId, YoutubeThumbnail.MaxResDefault);
         var maxResDefaultOkayResponse = client.GetAsync(new Uri(maxResDefaultOkay)).Result;
         Assert.That(maxResDefaultOkayResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK));
 

--- a/FriendToNetWebDevelopers.MicroUtilities/Enum/TryGetValidIdDefaultStrategyEnum.cs
+++ b/FriendToNetWebDevelopers.MicroUtilities/Enum/TryGetValidIdDefaultStrategyEnum.cs
@@ -1,7 +1,23 @@
 ﻿namespace FriendToNetWebDevelopers.MicroUtilities.Enum;
 
+/// <summary>
+/// Defines the fallback strategy used by
+/// <see cref="Utilities.Id.TryGetAsValidId(string?, TryGetValidIdDefaultStrategyEnum, out string)"/>
+/// when the proposed id value is invalid.
+/// </summary>
 public enum TryGetValidIdDefaultStrategyEnum
 {
+    /// <summary>
+    /// Returns <see cref="string.Empty"/> when the proposed id is invalid.
+    /// Use this when you want to handle the invalid case yourself — for example,
+    /// to omit the id attribute entirely or apply a custom fallback.
+    /// </summary>
     EmptyOnInvalid,
+
+    /// <summary>
+    /// Returns a freshly generated valid id (via <see cref="Utilities.Id.GetValidHtmlId()"/>)
+    /// when the proposed id is invalid.
+    /// Use this when a valid id is always required and the specific value does not matter.
+    /// </summary>
     GenerateOnInvalid
 }

--- a/FriendToNetWebDevelopers.MicroUtilities/Enum/YoutubeThumbnailEnum.cs
+++ b/FriendToNetWebDevelopers.MicroUtilities/Enum/YoutubeThumbnailEnum.cs
@@ -2,23 +2,32 @@
 
 namespace FriendToNetWebDevelopers.MicroUtilities.Enum;
 
-public class YoutubeThumbnailEnum
+/// <summary>
+/// Represents a YouTube thumbnail quality level.
+/// </summary>
+/// <remarks>
+/// This is a type-safe enum (smart enum) rather than a <see cref="System.Enum"/> — the string
+/// values map directly to YouTube's thumbnail filename conventions and are used as URL path
+/// segments via <see cref="ToString"/>.
+/// </remarks>
+public sealed class YoutubeThumbnail
 {
-    private const string MAX_RES_DEFAULT = "maxresdefault";
-    private const string HQ_DEFAULT = "hqdefault";
+    private const string MaxResDefaultValue = "maxresdefault";
+    private const string HqDefaultValue = "hqdefault";
 
     private string Name { get; }
 
-    private YoutubeThumbnailEnum(string name)
+    private YoutubeThumbnail(string name)
     {
         Name = name;
     }
 
-    public override string ToString()
-    {
-        return Name;
-    }
+    /// <inheritdoc/>
+    public override string ToString() => Name;
 
-    public static readonly YoutubeThumbnailEnum MaxResDefault = new(MAX_RES_DEFAULT);
-    public static readonly YoutubeThumbnailEnum HqDefault = new(HQ_DEFAULT);
+    /// <summary>Maximum resolution thumbnail (1280×720). May not be available for all videos.</summary>
+    public static readonly YoutubeThumbnail MaxResDefault = new(MaxResDefaultValue);
+
+    /// <summary>High quality thumbnail (480×360). Available for all videos.</summary>
+    public static readonly YoutubeThumbnail HqDefault = new(HqDefaultValue);
 }

--- a/FriendToNetWebDevelopers.MicroUtilities/FriendToNetWebDevelopers.MicroUtilities.csproj
+++ b/FriendToNetWebDevelopers.MicroUtilities/FriendToNetWebDevelopers.MicroUtilities.csproj
@@ -5,7 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <Version>1.6.1</Version>
+        <Version>2.0.0</Version>
         <Title>Micro Utilities</Title>
         <Authors>Christopher Goehrs via FriendToNetWebDevelopers</Authors>
         <Description>A set of tiny utilities to help on web projects</Description>
@@ -14,12 +14,12 @@
         <RepositoryType>Git</RepositoryType>
         <PackageTags>html,youtube,uri,url,dynamic ids</PackageTags>
         <Company>FriendToNetWebDevelopers</Company>
-        <AssemblyVersion>1.6.1</AssemblyVersion>
-        <FileVersion>1.6.1</FileVersion>
+        <AssemblyVersion>2.0.0</AssemblyVersion>
+        <FileVersion>2.0.0</FileVersion>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>
         <PackageIcon>icon.png</PackageIcon>
         <PackageReadmeFile>README.md</PackageReadmeFile>
-        <TargetFrameworks>net10.0;net8.0;net9.0</TargetFrameworks>
+        <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/FriendToNetWebDevelopers.MicroUtilities/Models/EmailAnnotator/Models.cs
+++ b/FriendToNetWebDevelopers.MicroUtilities/Models/EmailAnnotator/Models.cs
@@ -1,34 +1,105 @@
 ﻿namespace FriendToNetWebDevelopers.MicroUtilities.Models.EmailAnnotator;
 
-
+/// <summary>
+/// Classifies the type of a character token within an address string.
+/// </summary>
 public enum CharacterType
 {
-    EmailStructural, // @ . + (email sub-address delimiter)
-    UriStructural, // @ . (uri userinfo delimiter — + is not semantic)
-    AsciiAlpha, // a-z A-Z
-    AsciiDigit, // 0-9
-    AsciiSpecial, // printable ASCII punctuation, context-dependent allowed chars
-    PercentEncoded, // %XX sequences (URI mode only)
-    Unicode, // code points > U+007F
-    Invalid // characters not permitted in this context
+    /// <summary>Structural character in an email address — <c>@</c>, <c>.</c>, <c>+</c> (sub-address delimiter).</summary>
+    EmailStructural,
+
+    /// <summary>Structural character in a URI userinfo component — <c>@</c>, <c>.</c>.</summary>
+    UriStructural,
+
+    /// <summary>ASCII letter (a–z, A–Z).</summary>
+    AsciiAlpha,
+
+    /// <summary>ASCII digit (0–9).</summary>
+    AsciiDigit,
+
+    /// <summary>Printable ASCII punctuation that is permitted in this context.</summary>
+    AsciiSpecial,
+
+    /// <summary>Percent-encoded sequence (<c>%XX</c>). URI mode only.</summary>
+    PercentEncoded,
+
+    /// <summary>Unicode code point above U+007F.</summary>
+    Unicode,
+
+    /// <summary>Character not permitted in this address context.</summary>
+    Invalid
 }
 
+/// <summary>
+/// Specifies the address format being annotated, which determines which characters
+/// are considered structural, allowed, or invalid.
+/// </summary>
 public enum InputMode
 {
-    Email, // RFC 5321 / 6531 — raw Unicode allowed, + is semantic
-    Uri // RFC 3986 — userinfo, percent-encoding expected, + is not semantic
+    /// <summary>
+    /// RFC 5321 / 6531 email address. Raw Unicode is allowed in the local part and domain.
+    /// <c>+</c> is a semantic sub-address delimiter.
+    /// </summary>
+    Email,
+
+    /// <summary>
+    /// RFC 3986 URI userinfo or host component. Percent-encoding is expected.
+    /// <c>+</c> is not semantic and is treated as an allowed special character.
+    /// </summary>
+    Uri
 }
 
+/// <summary>
+/// Represents a single character (or percent-encoded sequence) within an address string,
+/// along with its classification and security-relevant metadata.
+/// </summary>
+/// <param name="Char">
+/// The character or sequence as a string. Uses <see cref="string"/> rather than <see cref="char"/>
+/// to accommodate surrogate pairs (supplementary plane characters) and percent-encoded sequences.
+/// </param>
+/// <param name="Codepoint">The Unicode code point in <c>U+XXXX</c> notation.</param>
+/// <param name="Type">The character's classification within this address context.</param>
+/// <param name="Script">
+/// The Unicode script block name for non-ASCII characters (e.g. <c>"Cyrillic"</c>, <c>"Greek"</c>).
+/// Null for ASCII characters.
+/// </param>
+/// <param name="HomoglyphOf">
+/// The ASCII character this code point visually resembles, if it appears in the homoglyph table.
+/// Null if no known homoglyph match. When non-null, <see cref="IsSuspicious"/> will be true.
+/// </param>
+/// <param name="IsStructural">
+/// True when this character is structural in the current address mode — i.e.
+/// <see cref="Type"/> is <see cref="CharacterType.EmailStructural"/> or
+/// <see cref="CharacterType.UriStructural"/>. Derived from <see cref="Type"/> for
+/// convenience; callers may also check <c>Type == CharacterType.EmailStructural</c> directly.
+/// </param>
+/// <param name="IsSuspicious">
+/// True when the character is a known homoglyph of an ASCII character, or when the token
+/// is otherwise flagged as potentially deceptive (e.g. mixed-script input).
+/// </param>
 public record CharacterToken(
     string Char,
     string Codepoint,
     CharacterType Type,
     string? Script,
     string? HomoglyphOf,
-    bool IsEmailStructural,
+    bool IsStructural,
     bool IsSuspicious
 );
 
+/// <summary>
+/// Contains the full token-level annotation of an address string, split into its
+/// local part and domain (for email) or userinfo and host (for URIs).
+/// </summary>
+/// <param name="Raw">The original, unmodified input string.</param>
+/// <param name="LocalPart">The portion of the address before the last <c>@</c>.</param>
+/// <param name="Domain">The portion of the address after the last <c>@</c>. Empty if no <c>@</c> was present.</param>
+/// <param name="Mode">The <see cref="InputMode"/> used when annotating this address.</param>
+/// <param name="LocalTokens">Per-character tokens for the local part.</param>
+/// <param name="DomainTokens">Per-character tokens for the domain.</param>
+/// <param name="ContainsUnicode">True if any token has <see cref="CharacterType.Unicode"/>.</param>
+/// <param name="ContainsSuspiciousChars">True if any token has <see cref="CharacterToken.IsSuspicious"/> set.</param>
+/// <param name="ContainsInvalidChars">True if any token has <see cref="CharacterType.Invalid"/>.</param>
 public record AddressPartAnnotation(
     string Raw,
     string LocalPart,
@@ -41,11 +112,29 @@ public record AddressPartAnnotation(
     bool ContainsInvalidChars
 );
 
+/// <summary>
+/// Describes the encoding form of a domain name input, used to detect
+/// suspicious or malformed submissions.
+/// </summary>
 public enum DomainInputForm
 {
-    PlainAscii,    // alice@example.com — boring, good
-    Unicode,       // alice@münchen.de — legitimate but needs scrutiny
-    Punycode,      // alice@xn--mnchen-3ya.de — suspicious from a human
-    Mixed,         // some labels unicode, some xn-- — malformed, red flag
-    Invalid        // couldn't be parsed/converted at all
+    /// <summary>All-ASCII domain with no <c>xn--</c> labels. The common, expected form.</summary>
+    PlainAscii,
+
+    /// <summary>Domain contains non-ASCII Unicode characters. Legitimate for IDNs but warrants scrutiny.</summary>
+    Unicode,
+
+    /// <summary>
+    /// Domain contains <c>xn--</c> Punycode labels. Suspicious when submitted by a human —
+    /// browsers and mail clients normalise to Unicode for display.
+    /// </summary>
+    Punycode,
+
+    /// <summary>
+    /// Domain contains a mix of Unicode and Punycode labels. Structurally malformed — strong red flag.
+    /// </summary>
+    Mixed,
+
+    /// <summary>Domain could not be parsed or converted. Treat as invalid input.</summary>
+    Invalid
 }

--- a/FriendToNetWebDevelopers.MicroUtilities/Models/PunyUniResult.cs
+++ b/FriendToNetWebDevelopers.MicroUtilities/Models/PunyUniResult.cs
@@ -11,12 +11,30 @@ public record PunyUniResult(
     bool IsSuspicious)
 {
     /// <summary>
-    /// Creates a new instance of the <see cref="PunyUniResult"/> class by analyzing the provided domain input.
-    /// This method determines whether the input is in Punycode, Unicode, or a mixed form and evaluates its validity and suspiciousness.
+    /// Creates a <see cref="PunyUniResult"/> by analysing the provided domain string.
+    /// Determines whether the input is PlainAscii, Unicode, Punycode, or Mixed, and
+    /// produces both the Unicode and Punycode canonical forms.
     /// </summary>
-    /// <param name="input">The domain input to be analyzed. This can be in Plain ASCII, Unicode, or Punycode formats.</param>
-    /// <returns>Returns an instance of the <see cref="PunyUniResult"/> class containing the analyzed input,
-    /// derived Unicode and Punycode representations, the detected input form, and an indicator of whether the input is suspicious.
+    /// <remarks>
+    /// <para>
+    /// <b>Suspicious flag:</b> Results are marked suspicious when the input form is
+    /// <see cref="DomainInputForm.Punycode"/>, <see cref="DomainInputForm.Mixed"/>, or
+    /// <see cref="DomainInputForm.Invalid"/>. A human submitting raw Punycode
+    /// (<c>xn--mnchen-3ya.de</c> instead of <c>münchen.de</c>) is unusual and worth
+    /// surfacing to the caller for review, even though normalization can still succeed.
+    /// </para>
+    /// <para>
+    /// <b>PlainAscii validation:</b> Plain ASCII domains (no Unicode, no <c>xn--</c> labels)
+    /// are still run through <see cref="IdnMapping.GetAscii"/> to validate structural
+    /// correctness — label length limits, illegal characters, and so on. A string like
+    /// <c>"not a domain!"</c> will produce <see cref="DomainInputForm.Invalid"/> rather
+    /// than passing through unchecked.
+    /// </para>
+    /// </remarks>
+    /// <param name="input">The domain string to analyse. Null or empty returns an Invalid result.</param>
+    /// <returns>
+    /// A <see cref="PunyUniResult"/> containing the input, its Unicode and Punycode forms,
+    /// the detected <see cref="DomainInputForm"/>, and a suspicious-input flag.
     /// </returns>
     public static PunyUniResult From(string? input)
     {
@@ -24,27 +42,68 @@ public record PunyUniResult(
             return new PunyUniResult(input, null, null, DomainInputForm.Invalid, true);
 
         var form = Detect(input);
+
+        if (form is DomainInputForm.Invalid)
+            return new PunyUniResult(input, null, null, DomainInputForm.Invalid, true);
+
         var suspicious = form is DomainInputForm.Punycode
             or DomainInputForm.Mixed
             or DomainInputForm.Invalid;
+
+        var idn = new IdnMapping();
+
         try
         {
-            var idn = new IdnMapping();
-            var unicode = form is DomainInputForm.Punycode or DomainInputForm.Mixed
-                ? idn.GetUnicode(input)
-                : input;
-            var punycode = form is DomainInputForm.Unicode or DomainInputForm.Mixed
-                ? idn.GetAscii(input)
-                : input;
+            string punycode;
+            string unicode;
+
+            switch (form)
+            {
+                case DomainInputForm.Punycode:
+                case DomainInputForm.Mixed:
+                    // Input is already (partially) Punycode — decode to Unicode first,
+                    // then re-encode to get a clean canonical Punycode form.
+                    unicode = idn.GetUnicode(input);
+                    punycode = idn.GetAscii(unicode);
+                    break;
+
+                case DomainInputForm.Unicode:
+                    // Pure Unicode input — encode to Punycode.
+                    punycode = idn.GetAscii(input);
+                    unicode = idn.GetUnicode(punycode);
+                    break;
+
+                case DomainInputForm.PlainAscii:
+                default:
+                    // Plain ASCII — run through GetAscii to validate structure
+                    // (label lengths, illegal characters, etc.) even though no
+                    // encoding is needed. A structurally invalid domain like
+                    // "not a domain!" will throw ArgumentException here.
+                    punycode = idn.GetAscii(input);
+                    unicode = idn.GetUnicode(punycode);
+                    break;
+            }
 
             return new PunyUniResult(input, unicode, punycode, form, suspicious);
         }
-        catch
+        catch (ArgumentException)
         {
+            // IdnMapping throws ArgumentException for malformed labels —
+            // illegal characters, labels exceeding 63 chars, empty labels, etc.
             return new PunyUniResult(input, null, null, DomainInputForm.Invalid, true);
         }
     }
 
+    /// <summary>
+    /// Detects the <see cref="DomainInputForm"/> of a domain string by inspecting its labels.
+    /// </summary>
+    /// <remarks>
+    /// Detection is based on the presence of <c>xn--</c> prefixed labels (Punycode) and
+    /// code points above U+007F (Unicode). A domain with both is <see cref="DomainInputForm.Mixed"/>,
+    /// which is structurally malformed and treated as suspicious.
+    /// </remarks>
+    /// <param name="domain">The domain string to inspect. Must not be null.</param>
+    /// <returns>The detected <see cref="DomainInputForm"/>.</returns>
     private static DomainInputForm Detect(string domain)
     {
         var labels = domain.Split('.');

--- a/FriendToNetWebDevelopers.MicroUtilities/Utility/AddressAnnotator.cs
+++ b/FriendToNetWebDevelopers.MicroUtilities/Utility/AddressAnnotator.cs
@@ -9,12 +9,15 @@ public static partial class Utilities
 {
     /// <summary>
     /// Provides methods to process and annotate address strings, such as email addresses or URIs,
-    /// by analyzing their structure, tokens, and character properties.
+    /// by analysing their structure, tokens, and character properties.
     /// </summary>
     public static class AddressAnnotator
     {
-        // Known homoglyphs: Unicode char → visually similar ASCII char.
-        // Extend this table as needed; sourced from Unicode TR39 confusables.
+        // Partial homoglyph table — high-priority confusables only.
+        // Characters that are visually indistinguishable from ASCII equivalents in common fonts
+        // and are frequently used in phishing/spoofing attacks.
+        // Sourced from Unicode TR39 confusables: https://www.unicode.org/reports/tr39/#confusables
+        // Extend this table as needed — the full TR39 list contains thousands of entries.
         private static readonly IReadOnlyDictionary<int, char> Homoglyphs =
             new Dictionary<int, char>
             {
@@ -27,102 +30,99 @@ public static partial class Utilities
                 [0x00F6] = 'o', [0x00FC] = 'u', [0x00E4] = 'a',
             };
 
-        // Email-allowed ASCII special characters per RFC 5321 local-part
+        // Email-allowed ASCII special characters in the local part per RFC 5321.
+        // Note: '+' is intentionally excluded here — it is classified as EmailStructural
+        // by _classifyChar before this set is consulted, so including it would be dead data.
         private static readonly HashSet<char> EmailSpecialChars =
-            ['!', '#', '$', '%', '&', '\'', '*', '+', '-', '/', '=', '?', '^', '_', '`', '{', '|', '}', '~', '.'];
+            ['!', '#', '$', '%', '&', '\'', '*', '-', '/', '=', '?', '^', '_', '`', '{', '|', '}', '~', '.'];
 
-        // URI userinfo allowed ASCII special characters per RFC 3986
+        // URI userinfo allowed ASCII special characters per RFC 3986.
         private static readonly HashSet<char> UriSpecialChars =
             ['!', '$', '&', '\'', '(', ')', '*', '+', ',', ';', '=', '-', '.', '_', '~', '%'];
 
         /// <summary>
-        /// Analyzes and annotates the user information portion of a given URI by evaluating its structure,
-        /// tokens, and relevant character properties, excluding sensitive parts such as passwords.
+        /// Analyses and annotates the user information portion of a given URI by evaluating
+        /// its structure, tokens, and character properties, excluding any password component.
         /// </summary>
         /// <param name="uri">
-        /// The URI containing the user information to be analyzed. This should be a valid URI from which
-        /// the user information will be extracted and annotated.
+        /// The URI containing the user information to analyse. Should be a valid absolute URI.
         /// </param>
         /// <returns>
-        /// An <see cref="AddressPartAnnotation"/> object containing the annotated user information
-        /// along with associated metadata including tokens, suspicious or invalid characters, and Unicode indicators.
+        /// An <see cref="AddressPartAnnotation"/> containing the annotated userinfo along with
+        /// metadata including tokens, suspicious or invalid characters, and Unicode indicators.
+        /// Returns an annotation for an empty string if no userinfo is present.
         /// </returns>
         public static AddressPartAnnotation AnnotateUserInfo(Uri uri)
         {
-            // Re-parse from the raw original string so nothing has been decoded
+            // Re-parse from the raw original string so percent-encoding is not decoded
             var original = uri.OriginalString;
-    
-            // Find the authority section (after :// )
+
+            // Find the authority section (after "://")
             var authorityStart = original.IndexOf("://", StringComparison.Ordinal);
             var authority = authorityStart >= 0
                 ? original[(authorityStart + 3)..]
                 : original;
 
-            // Strip anything after the authority (path, query, fragment)
+            // Strip path, query, and fragment
             var authorityEnd = authority.IndexOfAny(['/', '?', '#']);
             if (authorityEnd >= 0)
                 authority = authority[..authorityEnd];
 
-            // Find @ to identify userInfo
+            // Find '@' to identify userinfo
             var atIndex = authority.IndexOf('@');
             if (atIndex < 0)
                 return Annotate(string.Empty, InputMode.Uri);
 
             var userInfo = authority[..atIndex];
+
+            // Drop the password portion (":password") — never annotate credentials
             var passwordColon = userInfo.IndexOf(':');
             if (passwordColon >= 0)
-                userInfo = userInfo[..passwordColon]; // drop ":password" part
+                userInfo = userInfo[..passwordColon];
 
             return Annotate(userInfo, InputMode.Uri);
         }
 
         /// <summary>
-        /// Analyzes and annotates the host part of a given URI by evaluating its structure,
-        /// tokens, and relevant character properties.
+        /// Analyses and annotates the host component of a given URI.
         /// </summary>
-        /// <param name="uri">
-        /// The URI to be analyzed. This parameter should contain a valid URI in which
-        /// the host part will be extracted and annotated.
-        /// </param>
+        /// <param name="uri">The URI whose host will be annotated.</param>
         /// <returns>
-        /// An <see cref="AddressPartAnnotation"/> object that includes the raw host,
-        /// tokenized representation, and metadata about the host's character types
-        /// such as suspicious or invalid characters.
+        /// An <see cref="AddressPartAnnotation"/> containing the annotated host along with
+        /// metadata including tokens, suspicious or invalid characters, and Unicode indicators.
         /// </returns>
         public static AddressPartAnnotation AnnotateHost(Uri uri) => Annotate(uri.Host, InputMode.Uri);
 
         /// <summary>
-        /// Processes the given email address and generates an annotation containing detailed
-        /// information about its structure, tokens, and character properties.
+        /// Analyses and annotates a <see cref="MailAddress"/>, producing token-level detail
+        /// about its local part and domain.
         /// </summary>
-        /// <param name="address">
-        /// The email address to be annotated. This is passed as a <see cref="MailAddress"/> object
-        /// and contains both the local and domain parts of the email.
-        /// </param>
+        /// <param name="address">The email address to annotate.</param>
         /// <returns>
-        /// An <see cref="AddressPartAnnotation"/> object containing the raw email address,
-        /// separated local and domain parts, tokens for each part, and metadata such as whether
-        /// it contains Unicode, suspicious characters, or invalid characters.
+        /// An <see cref="AddressPartAnnotation"/> containing the raw address, separated local
+        /// and domain parts, per-character tokens, and metadata such as Unicode presence,
+        /// suspicious characters, and invalid characters.
         /// </returns>
-        public static AddressPartAnnotation Annotate(MailAddress address) => Annotate(address.Address, InputMode.Email);
-        
+        public static AddressPartAnnotation Annotate(MailAddress address) =>
+            Annotate(address.Address, InputMode.Email);
+
         /// <summary>
-        /// Processes the given address string and generates an annotation containing detailed
-        /// information about its structure, tokens, and character properties.
+        /// Analyses and annotates an address string, producing token-level detail about
+        /// its local part and domain (or userinfo and host for URIs).
         /// </summary>
         /// <param name="address">
-        /// The input address string to be annotated. This can represent an email address or a URI,
-        /// depending on the provided input mode.
+        /// The address string to annotate. Can be an email address or a URI userinfo/host string
+        /// depending on <paramref name="mode"/>.
         /// </param>
         /// <param name="mode">
-        /// Specifies the processing mode for the annotation. Set to <see cref="InputMode.Email"/>
-        /// for email processing or <see cref="InputMode.Uri"/> for URI processing. Defaults to
-        /// <see cref="InputMode.Email"/>.
+        /// Specifies the processing mode. Use <see cref="InputMode.Email"/> for RFC 5321 / 6531
+        /// email addresses, or <see cref="InputMode.Uri"/> for RFC 3986 URI components.
+        /// Defaults to <see cref="InputMode.Email"/>.
         /// </param>
         /// <returns>
-        /// An <see cref="AddressPartAnnotation"/> object containing the raw address,
-        /// separated local and domain parts, tokens for each part, and metadata such as
-        /// whether it contains Unicode, suspicious characters, or invalid characters.
+        /// An <see cref="AddressPartAnnotation"/> containing the raw address, separated local
+        /// and domain parts, per-character tokens, and metadata such as Unicode presence,
+        /// suspicious characters, and invalid characters.
         /// </returns>
         public static AddressPartAnnotation Annotate(string address, InputMode mode = InputMode.Email)
         {
@@ -131,8 +131,8 @@ public static partial class Utilities
             var local = atIndex >= 0 ? address[..atIndex] : address;
             var domain = atIndex >= 0 ? address[(atIndex + 1)..] : string.Empty;
 
-            var localTokens = _tokenizeSegment(local, mode);
-            var domainTokens = _tokenizeSegment(domain, mode);
+            var localTokens = TokenizeSegment(local, mode);
+            var domainTokens = TokenizeSegment(domain, mode);
 
             var allTokens = localTokens.Concat(domainTokens).ToList();
 
@@ -149,17 +149,18 @@ public static partial class Utilities
             );
         }
 
-        private static IReadOnlyList<CharacterToken> _tokenizeSegment(string segment, InputMode mode)
+        private static IReadOnlyList<CharacterToken> TokenizeSegment(string segment, InputMode mode)
         {
             var tokens = new List<CharacterToken>();
             var i = 0;
 
             while (i < segment.Length)
             {
-                // ── Percent-encoded sequence (%XX) ──────────────────────────────
+                // Percent-encoded sequence (%XX) — URI mode only
                 if (mode == InputMode.Uri && segment[i] == '%'
                                           && i + 2 < segment.Length
-                                          && _isHexChar(segment[i + 1]) && _isHexChar(segment[i + 2]))
+                                          && IsHexChar(segment[i + 1])
+                                          && IsHexChar(segment[i + 2]))
                 {
                     var encoded = segment.Substring(i, 3);
                     tokens.Add(new CharacterToken(
@@ -168,41 +169,42 @@ public static partial class Utilities
                         Type: CharacterType.PercentEncoded,
                         Script: null,
                         HomoglyphOf: null,
-                        IsEmailStructural: false,
+                        IsStructural: false,
                         IsSuspicious: false
                     ));
                     i += 3;
                     continue;
                 }
 
-                // ── Multi-char grapheme cluster (surrogate pairs, combining chars) ─
+                // Surrogate pair (supplementary plane character, e.g. emoji)
                 var codepoint = char.IsHighSurrogate(segment[i]) && i + 1 < segment.Length
                     ? char.ConvertToUtf32(segment[i], segment[i + 1])
                     : segment[i];
                 var charLen = codepoint > 0xFFFF ? 2 : 1;
                 var ch = segment.Substring(i, charLen);
 
-                tokens.Add(_classifyChar(ch, codepoint, mode));
+                tokens.Add(ClassifyChar(ch, codepoint, mode));
                 i += charLen;
             }
 
             return tokens;
         }
 
-        private static CharacterToken _classifyChar(string ch, int codepoint, InputMode mode)
+        private static CharacterToken ClassifyChar(string ch, int codepoint, InputMode mode)
         {
             var codepointStr = $"U+{codepoint:X4}";
 
             switch (codepoint)
             {
-                // ── @ separator ─────────────────────────────────────────────────────
+                // '@' separator — structural in both modes
                 case '@':
                     return new CharacterToken(ch, codepointStr,
                         mode == InputMode.Email
                             ? CharacterType.EmailStructural
                             : CharacterType.UriStructural,
                         null, null, true, false);
-                // ── ASCII range ──────────────────────────────────────────────────────
+
+                // ASCII range (U+0000–U+007F)
                 case <= 0x7F:
                 {
                     var c = (char)codepoint;
@@ -215,20 +217,22 @@ public static partial class Utilities
                         return new CharacterToken(ch, codepointStr,
                             CharacterType.AsciiDigit, "Basic Latin", null, false, false);
 
-                    // Structural: dot is structural in both modes;
-                    // + is structural/semantic in email only
+                    // Dot is structural in both modes.
+                    // '+' is structural/semantic in email only (sub-address delimiter per RFC 5321).
+                    //     In URI mode, '+' is an allowed special character, handled below.
                     var isDot = c == '.';
-                    var isPlus = c == '+';
-                    var isStructural = isDot || (isPlus && mode == InputMode.Email);
+                    var isEmailPlus = c == '+' && mode == InputMode.Email;
+                    var isStructural = isDot || isEmailPlus;
 
                     if (isStructural)
                         return new CharacterToken(ch, codepointStr,
                             mode == InputMode.Email
                                 ? CharacterType.EmailStructural
                                 : CharacterType.UriStructural,
-                            null, null, isStructural, false);
+                            null, null, true, false);
 
-                    // Allowed specials
+                    // Check against the mode-appropriate allowed specials set.
+                    // Note: '+' in URI mode reaches here and is correctly found in UriSpecialChars.
                     var allowed = mode == InputMode.Email
                         ? EmailSpecialChars.Contains(c)
                         : UriSpecialChars.Contains(c);
@@ -239,18 +243,17 @@ public static partial class Utilities
                 }
             }
 
-            // ── Unicode (non-ASCII) ──────────────────────────────────────────────
-            var script = _getScript(codepoint);
+            // Non-ASCII Unicode
+            var script = GetScript(codepoint);
             var homoglyph = Homoglyphs.TryGetValue(codepoint, out char similar)
                 ? similar.ToString()
                 : null;
-            var suspicious = homoglyph != null;
 
             return new CharacterToken(ch, codepointStr,
-                CharacterType.Unicode, script, homoglyph, false, suspicious);
+                CharacterType.Unicode, script, homoglyph, false, homoglyph != null);
         }
 
-        private static string _getScript(int codepoint) => codepoint switch
+        private static string GetScript(int codepoint) => codepoint switch
         {
             >= 0x0400 and <= 0x04FF => "Cyrillic",
             >= 0x0370 and <= 0x03FF => "Greek",
@@ -259,14 +262,15 @@ public static partial class Utilities
             >= 0x3040 and <= 0x309F => "Hiragana",
             >= 0x30A0 and <= 0x30FF => "Katakana",
             >= 0x0080 and <= 0x024F => "Latin Extended",
-            >= 0x0250 and <= 0x02AF => "IPA Extensions", //... and who doesn't love a good IPA?
+            >= 0x0250 and <= 0x02AF => "IPA Extensions",
             >= 0x1E00 and <= 0x1EFF => "Latin Extended Additional",
             _ => "Unknown"
         };
 
-        private static bool _isHexChar(char c) => c is >= '0' and <= '9' or >= 'a' and <= 'f' or >= 'A' and <= 'F';
+        private static bool IsHexChar(char c) =>
+            c is >= '0' and <= '9' or >= 'a' and <= 'f' or >= 'A' and <= 'F';
 
-        // ── JSON helper ───────────────────────────────────────────────────────────
+        // JSON serialisation helper
 
         private static readonly JsonSerializerOptions JsonOptions = new()
         {
@@ -275,8 +279,12 @@ public static partial class Utilities
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
         };
 
+        /// <summary>
+        /// Serialises an <see cref="AddressPartAnnotation"/> to indented JSON.
+        /// </summary>
+        /// <param name="annotation">The annotation to serialise.</param>
+        /// <returns>A JSON string representation of the annotation.</returns>
         public static string ToJson(AddressPartAnnotation annotation) =>
             JsonSerializer.Serialize(annotation, JsonOptions);
     }
 }
-

--- a/FriendToNetWebDevelopers.MicroUtilities/Utility/EmailUtilities.cs
+++ b/FriendToNetWebDevelopers.MicroUtilities/Utility/EmailUtilities.cs
@@ -313,6 +313,6 @@ public static partial class Utilities
     /// Note: This intentionally excludes the full RFC 5321 quoted-string form ("<c>"foo bar"@example.com</c>"),
     /// which is technically valid but essentially never seen in practice and commonly rejected by mail servers.
     /// </summary>
-    [GeneratedRegex(@"^[a-z0-9_]([.\-+a-z0-9_]*[a-z0-9_])?$")]
+    [GeneratedRegex(@"^[a-z0-9_]+([.\-+][a-z0-9_]+)*$")]
     private static partial Regex EmailUsernameRegex();
 }

--- a/FriendToNetWebDevelopers.MicroUtilities/Utility/EmailUtilities.cs
+++ b/FriendToNetWebDevelopers.MicroUtilities/Utility/EmailUtilities.cs
@@ -11,9 +11,13 @@ namespace FriendToNetWebDevelopers.MicroUtilities;
 public static partial class Utilities
 {
     /// <summary>
-    /// Handles various email validation
-    /// Limitations: Currently does not support email addresses with foreign characters
+    /// Handles various email validation and normalization operations.
     /// </summary>
+    /// <remarks>
+    /// Internationalized domain names (IDN) are fully supported via Punycode normalization.
+    /// Local parts are treated as case-sensitive per RFC 5321 — normalize before comparing
+    /// if case-insensitive matching is required.
+    /// </remarks>
     public static class Email
     {
         /// <summary>
@@ -21,73 +25,69 @@ public static partial class Utilities
         /// The validation includes checking for proper format, valid hostname, and top-level domain.
         /// </summary>
         /// <remarks>
-        /// Deliberately does not use built-in .NET email validation due to its limitations in handling certain edge cases.
-        /// This method focuses on a pure email address. Treats the email as a part of a Uri.
+        /// Deliberately does not use built-in .NET email validation due to its limitations in
+        /// handling certain edge cases. Treats the email as a part of a URI.
+        /// <para>
+        /// <b>Case sensitivity:</b> Local parts are case-sensitive per RFC 5321.
+        /// <c>User@example.com</c> and <c>user@example.com</c> are technically distinct addresses.
+        /// This method will return <c>false</c> for an email whose local part differs in case from
+        /// what the URI parser reconstructs. Normalize (e.g. <see cref="TryGetNormalizedValidPunyEmail(string?,out PunyUniResult?,out AddressPartAnnotation?)"/>)
+        /// before calling this if case-insensitive matching is desired.
+        /// </para>
         /// </remarks>
-        /// <param name="email">The email address to validate. Can be null or empty, but will return false in such cases.</param>
-        /// <returns>
-        /// True if the provided email address passes validation checks; otherwise, false.
-        /// </returns>
+        /// <param name="email">The email address to validate. Can be null or empty, in which case this returns false.</param>
+        /// <returns>True if the provided email address passes all validation checks; otherwise, false.</returns>
         /// <see cref="Uri.TryCreate(string, UriKind, out Uri)"/>
         public static bool IsValidEmail(string? email)
         {
             if (string.IsNullOrWhiteSpace(email)) return false;
             if (email.IndexOf('@') < 1) return false;
             if (email.Contains(':')) return false;
+
             var uriOkay = Uri.TryCreate($"https://{email}", UriKind.Absolute, out var uri);
             if (!uriOkay || uri == null) return false;
+
             var username = uri.UserInfo.Split(':')[0];
             if (!EmailUsernameRegex().IsMatch(username)) return false;
+
             if (uri.HostNameType is not (UriHostNameType.Dns or UriHostNameType.IPv4 or UriHostNameType.IPv6))
                 return false;
+
             if (uri.HostNameType is UriHostNameType.Dns && uri.Host.IndexOf('.') < 1) return false;
-            var puny = uri.DnsSafeHost;
+
             if (!Url.HasValidTopLevelDomain(uri)) return false;
+
+            // RFC 5321: local parts are case-sensitive. Uri preserves UserInfo casing but
+            // lowercases the host, so this equality check is intentionally exact on the local part.
             var spawned = $"{uri.UserInfo.Split(':')[0]}@{uri.DnsSafeHost}";
             return spawned == email;
         }
 
         /// <summary>
-        /// Attempts to validate and normalize the provided email address using specific normalization strategies.
-        /// Normalization includes transformations like converting to lowercase, trimming whitespace, and applying
-        /// other specified rules to produce a "pure" email representation.
+        /// Attempts to validate and normalize the provided email address using all normalization strategies.
         /// </summary>
         /// <remarks>
-        /// This method can ignore internal validation if explicitly instructed. The result is deemed valid
-        /// only if the normalization and validation operations succeed based on the specified strategy.
+        /// <b>Deprecated.</b> Use <see cref="TryGetNormalizedValidPunyEmail(string?,out PunyUniResult?,out AddressPartAnnotation?)"/> instead,
+        /// which returns both Punycode and Unicode forms and exposes suspicious-input flags.
         /// </remarks>
-        /// <param name="email">The email address to process. Can be null or empty, in which case normalization will fail.</param>
-        /// <param name="normalizedPure">Outputs the normalized, "pure" email address if processing succeeds; otherwise, null.</param>
-        /// <returns>
-        /// True if the email is valid and normalization is successful; otherwise, false.
-        /// </returns>
+        /// <param name="email">The email address to process. Can be null or empty, in which case this returns false.</param>
+        /// <param name="normalizedPure">The normalized email address if successful; otherwise, null.</param>
+        /// <returns>True if the email is valid and normalization succeeded; otherwise, false.</returns>
         [Obsolete("This method is deprecated. Please use TryGetNormalizedValidPunyEmail instead.")]
         public static bool TryGetNormalizedValidEmail(string? email, [NotNullWhen(true)] out string? normalizedPure)
             => TryGetNormalizedValidEmail(email, out normalizedPure, TryGetNormalizedValidEmailStrategyEnum.All);
 
         /// <summary>
-        /// Attempts to validate and normalize the given email address based on specified strategies.
-        /// If successful, returns a normalized version of the email address, otherwise returns false.
+        /// Attempts to validate and normalize the provided email address using all normalization strategies,
+        /// with optional skipping of internal validation.
         /// </summary>
         /// <remarks>
-        /// This method applies various strategies to normalize email addresses, such as removing tags,
-        /// trimming spaces, converting to lowercase, and dropping unnecessary dots (all strategies).
-        /// The email is considered valid only after passing internal validation (if not skipped).
+        /// <b>Deprecated.</b> Use <see cref="TryGetNormalizedValidPunyEmail(string?,out PunyUniResult?,out AddressPartAnnotation?)"/> instead.
         /// </remarks>
-        /// <param name="email">
-        /// The email address to process. Can be null or empty. The method will return false in such cases.
-        /// </param>
-        /// <param name="normalizedPure">
-        /// The output parameter that contains the normalized email address if the method returns true.
-        /// Will be null if the method returns false.
-        /// </param>
-        /// <param name="skipInternalValidation">
-        /// If set to true, skips internal validation logic and applies only the normalization strategies.
-        /// If false, email validation is performed before normalization.
-        /// </param>
-        /// <returns>
-        /// True if the email passes validation and is successfully normalized; otherwise, false.
-        /// </returns>
+        /// <param name="email">The email address to process. Can be null or empty, in which case this returns false.</param>
+        /// <param name="normalizedPure">The normalized email address if successful; otherwise, null.</param>
+        /// <param name="skipInternalValidation">If true, skips internal validation and applies only normalization strategies.</param>
+        /// <returns>True if the email is valid and normalization succeeded; otherwise, false.</returns>
         [Obsolete("This method is deprecated. Please use TryGetNormalizedValidPunyEmail instead.")]
         public static bool TryGetNormalizedValidEmail(string? email, [NotNullWhen(true)] out string? normalizedPure,
             bool skipInternalValidation)
@@ -96,26 +96,15 @@ public static partial class Utilities
 
         /// <summary>
         /// Attempts to normalize and validate an email address based on a customizable set of strategies.
-        /// Normalization processes can include converting to lowercase, removing tags, trimming whitespace,
-        /// and dropping dots from the username portion of the email address.
         /// </summary>
         /// <remarks>
-        /// If the email address is valid and normalization is successful, the method outputs the normalized
-        /// version of the email and returns true. Otherwise, it returns false.
-        /// The validation process may omit certain checks if specified by the parameters.
+        /// <b>Deprecated.</b> Use <see cref="TryGetNormalizedValidPunyEmail(string?,TryGetNormalizedValidEmailStrategyEnum,out PunyUniResult?,out AddressPartAnnotation?,bool)"/> instead.
         /// </remarks>
-        /// <param name="email">The input email address to validate and normalize.
-        /// Can be null, in which case the method returns false.</param>
-        /// <param name="normalizedPure">Outputs the normalized version of the email if the input is valid;
-        /// otherwise, null.</param>
-        /// <param name="strategy">Defines the specific actions to perform during the normalization
-        /// process, such as converting to lowercase, removing tags, or trimming whitespace.</param>
-        /// <param name="skipInternalValidation">Indicates whether to bypass additional validation steps
-        /// within the method. When true, some internal safety checks will be skipped.</param>
-        /// <returns>
-        /// True if the email is valid according to the provided parameters and normalization
-        /// succeeds; otherwise, false.
-        /// </returns>
+        /// <param name="email">The email address to validate and normalize. Can be null, in which case this returns false.</param>
+        /// <param name="normalizedPure">The normalized email address if successful; otherwise, null.</param>
+        /// <param name="strategy">The normalization strategies to apply.</param>
+        /// <param name="skipInternalValidation">If true, bypasses internal validation checks.</param>
+        /// <returns>True if the email is valid and normalization succeeded; otherwise, false.</returns>
         [Obsolete("This method is deprecated. Please use TryGetNormalizedValidPunyEmail instead.")]
         public static bool TryGetNormalizedValidEmail(
             string? email,
@@ -125,8 +114,10 @@ public static partial class Utilities
         {
             var okay = TryGetNormalizedValidPunyEmail(email, strategy, out var punyResult, out _,
                 skipInternalValidation);
+
             if (!okay || punyResult == null ||
-                punyResult.InputForm is DomainInputForm.Invalid or DomainInputForm.Mixed || punyResult.Unicode == null)
+                punyResult.InputForm is DomainInputForm.Invalid or DomainInputForm.Mixed ||
+                punyResult.Unicode == null)
             {
                 normalizedPure = null;
                 return false;
@@ -137,40 +128,72 @@ public static partial class Utilities
         }
 
         /// <summary>
-        /// Attempts to validate and normalize a provided email address into a punycode-compliant format.
-        /// The method ensures that the email address is syntactically valid, applies normalization strategies,
-        /// and provides additional annotations regarding the processed input.
+        /// Attempts to validate and normalize a provided email address into both Punycode and Unicode forms,
+        /// using all normalization strategies.
         /// </summary>
-        /// <param name="email">The email address to be normalized and validated. Can be null or empty.</param>
-        /// <param name="result">The output containing the original input, its Unicode representation,
-        /// the punycode representation, and a flag to indicate any suspicious properties.</param>
-        /// <param name="inputAnnotation">Additional annotation details for the email,
-        /// including breakdown of parts, tokenization, and character analysis information.</param>
-        /// <returns>
-        /// True if the email is valid and successfully normalized into punycode format; otherwise, false.
-        /// </returns>
+        /// <remarks>
+        /// This is the preferred overload for most callers. It applies all strategies: <c>ToLower</c>,
+        /// <c>Trim</c>, <c>DropTag</c>, and <c>DropDot</c>.
+        /// <para>
+        /// <b>Warning:</b> <c>DropTag</c> (plus-addressing) and <c>DropDot</c> are provider-specific
+        /// behaviours. <c>DropTag</c> is appropriate for Gmail and similar providers but may mangle
+        /// addresses on systems where <c>+</c> is not a sub-address delimiter (e.g. Fastmail, ProtonMail).
+        /// <c>DropDot</c> is Gmail-specific. If normalizing addresses for providers other than Gmail,
+        /// use the strategy overload and omit these flags.
+        /// </para>
+        /// </remarks>
+        /// <param name="email">The email address to normalize and validate. Can be null or empty.</param>
+        /// <param name="result">
+        /// The normalized result containing both Unicode and Punycode forms, the detected domain input form,
+        /// and a suspicious-input flag. Null if this method returns false.
+        /// </param>
+        /// <param name="inputAnnotation">
+        /// Character-level annotation of the input, including homoglyph detection and Unicode analysis.
+        /// Null if this method returns false.
+        /// </param>
+        /// <returns>True if the email is valid and normalization succeeded; otherwise, false.</returns>
         public static bool TryGetNormalizedValidPunyEmail(string? email,
             [NotNullWhen(true)] out PunyUniResult? result,
             [NotNullWhen(true)] out AddressPartAnnotation? inputAnnotation)
-            => TryGetNormalizedValidPunyEmail(email, TryGetNormalizedValidEmailStrategyEnum.All, out result, out inputAnnotation);
+            => TryGetNormalizedValidPunyEmail(email, TryGetNormalizedValidEmailStrategyEnum.All, out result,
+                out inputAnnotation);
 
         /// <summary>
-        /// Attempts to validate, normalize, and convert an email address to a Punycode representation based on a specified set of strategies.
-        /// This method performs checks and modifications such as trimming, case normalization, removal of tags, and dot normalization,
-        /// depending on the selected strategy flags.
+        /// Attempts to validate, normalize, and convert an email address to both Punycode and Unicode forms,
+        /// based on a specified set of strategies.
         /// </summary>
         /// <remarks>
-        /// The method aims to create a valid Punycode representation of an email address that complies with system-specific requirements.
-        /// Internal email validation checks can be optionally skipped. Multiple normalization strategies can be combined using bitwise operations.
+        /// <para>
+        /// <b>DropTag</b> removes plus sub-addressing (<c>foo+tag@example.com</c> → <c>foo@example.com</c>).
+        /// This is appropriate for Gmail but not for all providers. Do not include in <paramref name="strategy"/>
+        /// when normalizing addresses for Fastmail, ProtonMail, or other providers where <c>+</c> is not semantic.
+        /// </para>
+        /// <para>
+        /// <b>DropDot</b> removes dots from the local part (<c>first.last@gmail.com</c> → <c>firstlast@gmail.com</c>).
+        /// This is a Gmail-specific behaviour and should not be applied generally.
+        /// </para>
+        /// <para>
+        /// <b>Colon stripping</b> is always applied regardless of strategy — only hostile actors submit
+        /// colons in the local part.
+        /// </para>
         /// </remarks>
-        /// <param name="email">The email address to validate and normalize. Can be null or empty, which will result in a false return value.</param>
-        /// <param name="strategy">The strategies to apply during the normalization process. Supported flags include trimming, casing, tag removal, and dot normalization.</param>
-        /// <param name="result">The resulting <c>PunyUniResult</c> object containing the normalized Punycode representation of the email address. Will be null if the method returns false.</param>
-        /// <param name="inputAnnotation">An annotation object describing the parts of the input email address. Will be null if the method returns false.</param>
-        /// <param name="skipInternalValidation">A boolean value indicating whether to skip internal validation checks of the email address. Defaults to false.</param>
-        /// <returns>
-        /// True if the email address was successfully validated, normalized, and converted to Punycode; otherwise, false.
-        /// </returns>
+        /// <param name="email">The email address to validate and normalize. Can be null or empty, which results in false.</param>
+        /// <param name="strategy">
+        /// The normalization strategies to apply. Flags may be combined. See <see cref="TryGetNormalizedValidEmailStrategyEnum"/>
+        /// for available options and pre-built combinations.
+        /// </param>
+        /// <param name="result">
+        /// The normalized result if successful; otherwise, null. Contains Unicode and Punycode canonical forms,
+        /// the detected domain input form, and a suspicious-input flag.
+        /// </param>
+        /// <param name="inputAnnotation">
+        /// Character-level annotation of the raw input. Null if this method returns false.
+        /// </param>
+        /// <param name="skipInternalValidation">
+        /// If true, skips <see cref="IsValidEmail"/> checks. Useful for internal or custom domains
+        /// (e.g. <c>admin@internal</c>) that would not pass TLD validation.
+        /// </param>
+        /// <returns>True if the email was successfully validated, normalized, and converted; otherwise, false.</returns>
         public static bool TryGetNormalizedValidPunyEmail(
             string? email,
             TryGetNormalizedValidEmailStrategyEnum strategy,
@@ -188,18 +211,19 @@ public static partial class Utilities
             inputAnnotation = email.Annotate(InputMode.Email);
 
             var okay = MailAddress.TryCreate(email, out var parsedResult);
-            if (!okay || parsedResult == null || !skipInternalValidation && !IsValidEmail(parsedResult.Address))
+            if (!okay || parsedResult == null || (!skipInternalValidation && !IsValidEmail(parsedResult.Address)))
             {
                 result = null;
                 return false;
             }
 
             string normalized;
-            // Get rid of +(?) in an email address username (foo+1@bar.com)
-            if (((int)strategy & (int)TryGetNormalizedValidEmailStrategyEnum.DropTag) != 0)
+
+            // DropTag: remove plus sub-addressing (foo+tag@example.com → foo@example.com).
+            // Provider-specific — appropriate for Gmail; do not use for Fastmail, ProtonMail, etc.
+            if (strategy.HasFlag(TryGetNormalizedValidEmailStrategyEnum.DropTag))
             {
-                var user = parsedResult.User;
-                user = user.Split('+')[0];
+                var user = parsedResult.User.Split('+')[0];
                 normalized = $"{user}@{parsedResult.Host}";
             }
             else
@@ -207,20 +231,22 @@ public static partial class Utilities
                 normalized = parsedResult.Address;
             }
 
-            // This shouldn't be NECESSARY but because other safety measures can be skipped, I'm leaving it in
-            if (((int)strategy & (int)TryGetNormalizedValidEmailStrategyEnum.Trim) != 0)
+            // Trim: defensive — shouldn't be necessary after MailAddress.TryCreate, but
+            // included for correctness when skipInternalValidation is true.
+            if (strategy.HasFlag(TryGetNormalizedValidEmailStrategyEnum.Trim))
             {
                 normalized = normalized.Trim();
             }
 
-            // While I think this should ALWAYS be done, I'm leaving it in as an option for case-sensitive systems
-            if (((int)strategy & (int)TryGetNormalizedValidEmailStrategyEnum.ToLower) != 0)
+            // ToLower: recommended for all systems unless the downstream is explicitly case-sensitive.
+            if (strategy.HasFlag(TryGetNormalizedValidEmailStrategyEnum.ToLower))
             {
                 normalized = normalized.ToLowerInvariant();
             }
 
-            // Some systems, like Gmail, ignore dots in email addresses. This normalizes around that.
-            if (((int)strategy & (int)TryGetNormalizedValidEmailStrategyEnum.DropDot) != 0)
+            // DropDot: removes dots from the local part (first.last@gmail.com → firstlast@gmail.com).
+            // Gmail-specific behaviour — do not apply to other providers.
+            if (strategy.HasFlag(TryGetNormalizedValidEmailStrategyEnum.DropDot))
             {
                 var parts = normalized.Split('@');
                 if (parts.Length == 2)
@@ -229,8 +255,8 @@ public static partial class Utilities
                 }
             }
 
-            //Stripping ":" → I wasn't asking, for the most obvious reasons. Only hostile actors would try.
-            //   AND this only needs to be checked if internal validation is skipped
+            // Colon stripping — always applied, not negotiable.
+            // Colons in the local part have no legitimate use; only hostile actors submit them.
             {
                 var parts = normalized.Split('@');
                 if (parts.Length == 2)
@@ -239,7 +265,7 @@ public static partial class Utilities
                 }
             }
 
-            //Normalize to punycode and unicode. I wasn't asking.
+            // Punycode/Unicode normalization — always applied, not negotiable.
             {
                 var normalizedBaseParts = normalized.Split('@');
                 if (normalizedBaseParts.Length != 2)
@@ -248,11 +274,11 @@ public static partial class Utilities
                     return false;
                 }
 
-                //First, assume the user is hostile. Check if already punyfied.
+                // Assume hostile input. Check whether domain has already been Punycode-encoded.
                 var domainInput = normalizedBaseParts[1];
                 var punyResult = PunyUniResult.From(domainInput);
 
-                // Hostile or malformed — bail immediately
+                // Invalid or mixed-encoding domain — bail immediately.
                 if (punyResult.InputForm is DomainInputForm.Invalid or DomainInputForm.Mixed
                     || punyResult.Punycode == null)
                 {
@@ -260,17 +286,15 @@ public static partial class Utilities
                     return false;
                 }
 
-                // Anyone submitting raw Punycode is suspicious, but we can still
-                // normalize it — the annotation will surface the red flag to the caller
-                // punyResult.IsSuspicious is already set true for Punycode/Mixed/Invalid
-
+                // Raw Punycode submitted by a human is suspicious, but still normalizable.
+                // IsSuspicious is already set on punyResult for Punycode/Mixed/Invalid inputs.
+                // The annotation surfaces this to the caller.
                 var localPart = normalizedBaseParts[0];
-                var canonicalKey = $"{localPart}@{punyResult.Punycode}";
 
                 result = new PunyUniResult(
                     Input: normalized,
                     Unicode: $"{localPart}@{punyResult.Unicode}",
-                    Punycode: canonicalKey,
+                    Punycode: $"{localPart}@{punyResult.Punycode}",
                     InputForm: punyResult.InputForm,
                     IsSuspicious: punyResult.IsSuspicious || inputAnnotation.ContainsSuspiciousChars
                 );
@@ -280,6 +304,15 @@ public static partial class Utilities
         }
     }
 
-    [GeneratedRegex(@"^[a-z0-9_](\.{0,1}[\-\+a-z0-9_])*[a-z0-9_]$")]
+    /// <summary>
+    /// Matches a valid email local part per RFC 5321.
+    /// Rules:
+    ///   - Must start and end with an alphanumeric character or underscore.
+    ///   - Middle characters may include: letters, digits, underscores, hyphens, plus signs, and dots.
+    ///   - Single-character local parts (e.g. "a@example.com") are valid.
+    /// Note: This intentionally excludes the full RFC 5321 quoted-string form ("<c>"foo bar"@example.com</c>"),
+    /// which is technically valid but essentially never seen in practice and commonly rejected by mail servers.
+    /// </summary>
+    [GeneratedRegex(@"^[a-z0-9_]([.\-+a-z0-9_]*[a-z0-9_])?$")]
     private static partial Regex EmailUsernameRegex();
 }

--- a/FriendToNetWebDevelopers.MicroUtilities/Utility/IdUtilities.cs
+++ b/FriendToNetWebDevelopers.MicroUtilities/Utility/IdUtilities.cs
@@ -10,101 +10,152 @@ public static partial class Utilities
     {
         private static readonly Regex IdValueRegex = HtmlIdValueInternalRegex();
         private static readonly Regex IdPrefixValueRegex = HtmlIdPrefixValueInternalRegex();
-        
+
         private const string DefaultPrefix = "id";
-        
+
         /// <summary>
-        /// Default functionality for getting a dynamic id.  Generates a new guid.
+        /// Generates a valid HTML <c>id</c> attribute value from a new <see cref="Guid"/>.
         /// </summary>
-        /// <param name="prefix">REQUIRED NON-EMPTY, VALID, AT LEAST 2 CHARACTERS - default "id"</param>
-        /// <param name="suffix">OPTIONAL non-empty and valid</param>
-        /// <returns>Valid html id value</returns>
+        /// <param name="prefix">
+        /// Required. Must be at least one character, start with a letter, and contain only
+        /// letters, digits, hyphens, and underscores. Defaults to <c>"id"</c>.
+        /// </param>
+        /// <param name="suffix">
+        /// Optional. If provided, must be a valid id fragment (letters, digits, hyphens,
+        /// underscores). Whitespace is trimmed before use.
+        /// </param>
+        /// <returns>A valid HTML id attribute value.</returns>
+        /// <exception cref="BadIdPrefixException">Thrown when <paramref name="prefix"/> is invalid.</exception>
+        /// <exception cref="BadIdFormatException">Thrown when the assembled id fails final validation.</exception>
         public static string GetValidHtmlId(string prefix = DefaultPrefix, string suffix = "")
             => GetValidHtmlId(Guid.NewGuid(), prefix, suffix);
 
         /// <summary>
-        /// Generates a dynamic, valid html id based on the specified guid
+        /// Generates a valid HTML <c>id</c> attribute value from the specified <see cref="Guid"/>.
         /// </summary>
-        /// <param name="guid">The id which forms the base of the final dynamic id</param>
-        /// <param name="prefix">REQUIRED NON-EMPTY, VALID, AT LEAST 2 CHARACTERS - default "id"</param>
-        /// <param name="suffix">OPTIONAL non-empty and valid</param>
-        /// <returns>Valid html id value</returns>
+        /// <param name="guid">The GUID that forms the base of the id value.</param>
+        /// <param name="prefix">
+        /// Required. Must be at least one character, start with a letter, and contain only
+        /// letters, digits, hyphens, and underscores. Defaults to <c>"id"</c>.
+        /// </param>
+        /// <param name="suffix">
+        /// Optional. Whitespace is trimmed before use.
+        /// </param>
+        /// <returns>A valid HTML id attribute value.</returns>
+        /// <exception cref="BadIdPrefixException">Thrown when <paramref name="prefix"/> is invalid.</exception>
+        /// <exception cref="BadIdFormatException">Thrown when the assembled id fails final validation.</exception>
         public static string GetValidHtmlId(Guid guid, string prefix = DefaultPrefix, string suffix = "")
         {
-            if (!_isValidIdPrefix(prefix)) throw new BadIdPrefixException(prefix);
-            return _finalIdValidate($"{prefix}{guid:N}{suffix.Trim()}");
+            if (!IsValidIdPrefix(prefix)) throw new BadIdPrefixException(prefix);
+            return FinalIdValidate($"{prefix}{guid:N}{suffix.Trim()}");
         }
-        
+
         /// <summary>
-        /// Generates a dynamic, valid html id based on the specified id
+        /// Generates a valid HTML <c>id</c> attribute value from the specified <see cref="int"/> id.
         /// </summary>
-        /// <param name="id">The id which forms the base of the final dynamic id</param>
-        /// <param name="prefix">REQUIRED NON-EMPTY, VALID, AT LEAST 2 CHARACTERS - default "id"</param>
-        /// <param name="suffix">OPTIONAL non-empty and valid</param>
-        /// <returns>Valid html id value</returns>
+        /// <param name="id">The id value that forms the base of the HTML id.</param>
+        /// <param name="prefix">
+        /// Required. Must be at least one character, start with a letter, and contain only
+        /// letters, digits, hyphens, and underscores. Defaults to <c>"id"</c>.
+        /// </param>
+        /// <param name="suffix">Optional. Whitespace is trimmed before use.</param>
+        /// <returns>A valid HTML id attribute value.</returns>
+        /// <exception cref="BadIdPrefixException">Thrown when <paramref name="prefix"/> is invalid.</exception>
+        /// <exception cref="BadIdFormatException">Thrown when the assembled id fails final validation.</exception>
         public static string GetValidHtmlId(int id, string prefix = DefaultPrefix, string suffix = "")
         {
-            if (!_isValidIdPrefix(prefix)) throw new BadIdPrefixException(prefix);
-            return _finalIdValidate($"{prefix}{id:0}{suffix.Trim()}");
+            if (!IsValidIdPrefix(prefix)) throw new BadIdPrefixException(prefix);
+            return FinalIdValidate($"{prefix}{id:0}{suffix.Trim()}");
         }
-        
+
         /// <summary>
-        /// Generates a dynamic, valid html id based on the specified id
+        /// Generates a valid HTML <c>id</c> attribute value from the specified <see cref="uint"/> id.
         /// </summary>
-        /// <param name="id">The id which forms the base of the final dynamic id</param>
-        /// <param name="prefix">REQUIRED NON-EMPTY, VALID, AT LEAST 2 CHARACTERS - default "id"</param>
-        /// <param name="suffix">OPTIONAL non-empty and valid</param>
-        /// <returns>Valid html id value</returns>
+        /// <param name="id">The id value that forms the base of the HTML id.</param>
+        /// <param name="prefix">
+        /// Required. Must be at least one character, start with a letter, and contain only
+        /// letters, digits, hyphens, and underscores. Defaults to <c>"id"</c>.
+        /// </param>
+        /// <param name="suffix">Optional. Whitespace is trimmed before use.</param>
+        /// <returns>A valid HTML id attribute value.</returns>
+        /// <exception cref="BadIdPrefixException">Thrown when <paramref name="prefix"/> is invalid.</exception>
+        /// <exception cref="BadIdFormatException">Thrown when the assembled id fails final validation.</exception>
         public static string GetValidHtmlId(uint id, string prefix = DefaultPrefix, string suffix = "")
         {
-            if (!_isValidIdPrefix(prefix)) throw new BadIdPrefixException(prefix);
-            return _finalIdValidate($"{prefix}{id:0}{suffix.Trim()}");
+            if (!IsValidIdPrefix(prefix)) throw new BadIdPrefixException(prefix);
+            return FinalIdValidate($"{prefix}{id:0}{suffix.Trim()}");
         }
-        
+
         /// <summary>
-        /// Generates a dynamic, valid html id based on the specified id
+        /// Generates a valid HTML <c>id</c> attribute value from the specified <see cref="long"/> id.
         /// </summary>
-        /// <param name="id">The id which forms the base of the final dynamic id</param>
-        /// <param name="prefix">REQUIRED NON-EMPTY, VALID, AT LEAST 2 CHARACTERS - default "id"</param>
-        /// <param name="suffix">OPTIONAL non-empty and valid</param>
-        /// <returns>Valid html id value</returns>
+        /// <param name="id">The id value that forms the base of the HTML id.</param>
+        /// <param name="prefix">
+        /// Required. Must be at least one character, start with a letter, and contain only
+        /// letters, digits, hyphens, and underscores. Defaults to <c>"id"</c>.
+        /// </param>
+        /// <param name="suffix">Optional. Whitespace is trimmed before use.</param>
+        /// <returns>A valid HTML id attribute value.</returns>
+        /// <exception cref="BadIdPrefixException">Thrown when <paramref name="prefix"/> is invalid.</exception>
+        /// <exception cref="BadIdFormatException">Thrown when the assembled id fails final validation.</exception>
         public static string GetValidHtmlId(long id, string prefix = DefaultPrefix, string suffix = "")
         {
-            if (!_isValidIdPrefix(prefix)) throw new BadIdPrefixException(prefix);
-            return _finalIdValidate($"{prefix.Trim()}{id:0}{suffix.Trim()}");
+            if (!IsValidIdPrefix(prefix)) throw new BadIdPrefixException(prefix);
+            return FinalIdValidate($"{prefix}{id:0}{suffix.Trim()}");
         }
-        
+
         /// <summary>
-        /// Generates a dynamic, valid html id based on the specified id
+        /// Generates a valid HTML <c>id</c> attribute value from the specified <see cref="ulong"/> id.
         /// </summary>
-        /// <param name="id">The id which forms the base of the final dynamic id</param>
-        /// <param name="prefix">REQUIRED NON-EMPTY, VALID, AT LEAST 2 CHARACTERS - default "id"</param>
-        /// <param name="suffix">OPTIONAL non-empty and valid</param>
-        /// <returns>Valid html id value</returns>
+        /// <param name="id">The id value that forms the base of the HTML id.</param>
+        /// <param name="prefix">
+        /// Required. Must be at least one character, start with a letter, and contain only
+        /// letters, digits, hyphens, and underscores. Defaults to <c>"id"</c>.
+        /// </param>
+        /// <param name="suffix">Optional. Whitespace is trimmed before use.</param>
+        /// <returns>A valid HTML id attribute value.</returns>
+        /// <exception cref="BadIdPrefixException">Thrown when <paramref name="prefix"/> is invalid.</exception>
+        /// <exception cref="BadIdFormatException">Thrown when the assembled id fails final validation.</exception>
         public static string GetValidHtmlId(ulong id, string prefix = DefaultPrefix, string suffix = "")
         {
-            if (!_isValidIdPrefix(prefix)) throw new BadIdPrefixException(prefix);
-            return _finalIdValidate($"{prefix.Trim()}{id:0}{suffix.Trim()}");
+            if (!IsValidIdPrefix(prefix)) throw new BadIdPrefixException(prefix);
+            return FinalIdValidate($"{prefix}{id:0}{suffix.Trim()}");
         }
 
         /// <summary>
-        /// Checks if an id is valid
+        /// Determines whether the proposed string is a valid HTML <c>id</c> attribute value.
         /// </summary>
-        /// <param name="id">The proposed id attribute value</param>
-        /// <returns></returns>
-        public static bool IsValidId(string? id) => _isValidId(id);
+        /// <remarks>
+        /// Valid ids must start with a letter, end with a letter or digit, and contain only
+        /// letters, digits, hyphens, and underscores. Single-character ids (one letter) are valid.
+        /// Null, empty, and whitespace-only strings return false.
+        /// </remarks>
+        /// <param name="id">The proposed id attribute value.</param>
+        /// <returns>True if valid; otherwise, false.</returns>
+        public static bool IsValidId(string? id) => IsValidIdInternal(id);
 
         /// <summary>
-        /// Ensures the proposed id attribute value is valid. If invalid, it uses the fallback strategies to ensure the output is always non-nullable
+        /// Validates the proposed id attribute value and returns a guaranteed non-null string
+        /// using the specified fallback strategy when the input is invalid.
         /// </summary>
-        /// <param name="id">The proposed id attribute value</param>
-        /// <param name="fallbackStrategy">empty or generate</param>
-        /// <param name="validId">the output</param>
-        /// <returns></returns>
-        /// <exception cref="BadIdFormatException"></exception>
-        public static bool TryGetAsValidId(string? id, TryGetValidIdDefaultStrategyEnum fallbackStrategy, out string validId)
+        /// <param name="id">The proposed id attribute value.</param>
+        /// <param name="fallbackStrategy">
+        /// The strategy to apply when <paramref name="id"/> is invalid.
+        /// <see cref="TryGetValidIdDefaultStrategyEnum.EmptyOnInvalid"/> returns <see cref="string.Empty"/>;
+        /// <see cref="TryGetValidIdDefaultStrategyEnum.GenerateOnInvalid"/> returns a generated id
+        /// via <see cref="GetValidHtmlId()"/>.
+        /// </param>
+        /// <param name="validId">
+        /// The original id if valid, or the fallback value if not.
+        /// </param>
+        /// <returns>True if <paramref name="id"/> was already valid; false if the fallback was used.</returns>
+        /// <exception cref="BadIdFormatException">
+        /// Thrown when <paramref name="fallbackStrategy"/> is not a recognised value.
+        /// </exception>
+        public static bool TryGetAsValidId(string? id, TryGetValidIdDefaultStrategyEnum fallbackStrategy,
+            out string validId)
         {
-            if (_isValidId(id))
+            if (IsValidIdInternal(id))
             {
                 validId = id!;
                 return true;
@@ -118,23 +169,44 @@ public static partial class Utilities
             };
             return false;
         }
-        
-        private static string _finalIdValidate(string id)
+
+        private static string FinalIdValidate(string id)
         {
-            if (!_isValidId(id)) throw new BadIdFormatException(id);
+            if (!IsValidIdInternal(id)) throw new BadIdFormatException(id);
             return id;
         }
-        
-        private static bool _isValidIdPrefix(string? idString)
-            => DefaultPrefix == idString || 
-               (!string.IsNullOrWhiteSpace(idString) && IdPrefixValueRegex.IsMatch(idString));
-        
-        private static bool _isValidId(string? idString)
+
+        /// <summary>
+        /// Validates a proposed id prefix string.
+        /// A valid prefix must start with a letter and contain only letters, digits, hyphens,
+        /// and underscores. The default prefix <c>"id"</c> is always valid.
+        /// Whitespace in a prefix is a caller error — it is not trimmed silently.
+        /// </summary>
+        private static bool IsValidIdPrefix(string? prefix)
+            => !string.IsNullOrWhiteSpace(prefix) && IdPrefixValueRegex.IsMatch(prefix);
+
+        private static bool IsValidIdInternal(string? idString)
             => !string.IsNullOrWhiteSpace(idString) && IdValueRegex.IsMatch(idString);
     }
-    
-    [GeneratedRegex("^[a-zA-Z][a-zA-Z0-9_\\-]*[a-zA-Z0-9]$")]
+
+    /// <summary>
+    /// Matches a valid HTML id attribute value.
+    /// Rules:
+    ///   - Must start with a letter (a-z, A-Z).
+    ///   - May contain letters, digits, hyphens, and underscores in the middle.
+    ///   - Must end with a letter or digit — not a hyphen or underscore.
+    ///   - Single-character ids (one letter) are valid via the optional middle+end group.
+    /// </summary>
+    [GeneratedRegex("^[a-zA-Z]([a-zA-Z0-9_\\-]*[a-zA-Z0-9])?$")]
     private static partial Regex HtmlIdValueInternalRegex();
+
+    /// <summary>
+    /// Matches a valid HTML id prefix.
+    /// Rules:
+    ///   - Must start with a letter (a-z, A-Z).
+    ///   - May be followed by any number of letters, digits, hyphens, and underscores.
+    ///   - No minimum length beyond the leading letter — a single-letter prefix is valid.
+    /// </summary>
     [GeneratedRegex("^[a-zA-Z][a-zA-Z0-9_\\-]*$")]
     private static partial Regex HtmlIdPrefixValueInternalRegex();
 }

--- a/FriendToNetWebDevelopers.MicroUtilities/Utility/UriUtilities.cs
+++ b/FriendToNetWebDevelopers.MicroUtilities/Utility/UriUtilities.cs
@@ -14,32 +14,38 @@ public static partial class Utilities
         private const string SingleDot = ".";
         private const string DoubleDot = "..";
 
-        
         /// <summary>
-        /// Uri resource is built into a string.<br/>
-        /// In debug mode (localhost), a port number is included.
+        /// Builds an absolute URL string from a URI resource.
         /// </summary>
-        /// <param name="url">The Uri resource</param>
-        /// <param name="forceIncludePort">Will FORCE a port number to be included in the final url, ignoring debug mode</param>
-        /// <returns>An absolute url</returns>
+        /// <remarks>
+        /// In debug mode (localhost), the port number is included in the output so that
+        /// local development servers are addressed correctly (e.g. <c>https://localhost:44328/file.jpg</c>).
+        /// In non-debug (production) mode, the port is stripped for clean public-facing URLs
+        /// (e.g. <c>https://example.com/file.jpg</c>).
+        /// </remarks>
+        /// <param name="url">The URI resource to build from.</param>
+        /// <param name="forceIncludePort">
+        /// When true, forces the port number to be included regardless of debug mode.
+        /// </param>
+        /// <returns>An absolute URL string.</returns>
         public static string BuildAbsoluteUrl(Uri url, bool forceIncludePort = false)
         {
+            // Include port in debug/local mode so dev servers are reachable.
+            // Strip port in production for clean public-facing URLs.
             return IsDebug() || forceIncludePort
-                ? url.GetComponents(UriComponents.AbsoluteUri & ~UriComponents.Port, UriFormat.SafeUnescaped)
-                : url.GetComponents(UriComponents.AbsoluteUri, UriFormat.SafeUnescaped);
+                ? url.GetComponents(UriComponents.AbsoluteUri, UriFormat.SafeUnescaped)
+                : url.GetComponents(UriComponents.AbsoluteUri & ~UriComponents.Port, UriFormat.SafeUnescaped);
         }
-        
-        [Obsolete("Use IsValidPathSegment instead", false)]
-        public static bool PathSegmentIsValid(string? segment, bool emptyIsOkay = false) => IsValidPathSegment(segment, emptyIsOkay);
 
         /// <summary>
-        /// Determines whether a given string is a valid path segment.
+        /// Determines whether a given string is a valid URI path segment.
         /// </summary>
-        /// <param name="segment">The path segment to validate. It can be null or empty.</param>
-        /// <param name="emptyIsOkay">Specifies whether an empty segment is considered valid.</param>
+        /// <param name="segment">The path segment to validate. Can be null or empty.</param>
+        /// <param name="emptyIsOkay">Whether an empty segment is considered valid. Defaults to false.</param>
         /// <returns>
-        /// <c>true</c> if the segment is valid; otherwise, <c>false</c>.
+        /// True if the segment is valid; otherwise, false.
         /// A segment is considered valid if it is URL-encoded and matches the allowed segment pattern.
+        /// Single dot (<c>.</c>) and double dot (<c>..</c>) are always considered valid.
         /// </returns>
         public static bool IsValidPathSegment(string? segment, bool emptyIsOkay = false)
         {
@@ -49,11 +55,16 @@ public static partial class Utilities
             return HttpUtility.UrlEncode(segment) == segment && UrlSegmentRegex().IsMatch(segment);
         }
 
+        /// <inheritdoc cref="IsValidPathSegment(string?, bool)"/>
+        [Obsolete("Use IsValidPathSegment instead.", false)]
+        public static bool PathSegmentIsValid(string? segment, bool emptyIsOkay = false)
+            => IsValidPathSegment(segment, emptyIsOkay);
+
         /// <summary>
-        /// Validates whether the provided username is a valid userinfo component according to RFC 3986.
+        /// Validates whether the provided string is a valid URI userinfo component per RFC 3986.
         /// </summary>
         /// <param name="username">The username to validate. Can be null or empty.</param>
-        /// <param name="emptyIsOkay">Indicates whether an empty or null username is considered valid.</param>
+        /// <param name="emptyIsOkay">Whether a null or empty value is considered valid. Defaults to false.</param>
         /// <returns>True if the username is valid; otherwise, false.</returns>
         public static bool IsValidUsername(string? username, bool emptyIsOkay = false)
         {
@@ -63,7 +74,7 @@ public static partial class Utilities
         }
 
         /// <summary>
-        /// Validates whether the provided name is a valid query parameter name.
+        /// Validates whether the provided string is a valid URI query parameter name.
         /// </summary>
         /// <param name="name">The query parameter name to validate.</param>
         /// <returns>True if the name is valid; otherwise, false.</returns>
@@ -75,49 +86,58 @@ public static partial class Utilities
         #region Sluggery
 
         /// <summary>
-        /// Is the proposed slug valid
+        /// Determines whether the proposed slug is a valid URI slug.
         /// </summary>
-        /// <param name="slug">proposed slug</param>
-        /// <returns></returns>
+        /// <remarks>
+        /// Valid slugs match the pattern <c>^[a-z0-9]+(?:-[a-z0-9]+)*$</c> —
+        /// lowercase alphanumeric segments separated by single hyphens.
+        /// </remarks>
+        /// <param name="slug">The proposed slug to validate.</param>
+        /// <returns>True if the slug is valid; otherwise, false.</returns>
         public static bool IsValidUriSlug(string? slug)
         {
             return !string.IsNullOrWhiteSpace(slug) && UrlSlugRegex().IsMatch(slug);
         }
 
         /// <summary>
-        /// Convert a string into a slug
+        /// Attempts to convert a string into a valid URI slug.
         /// </summary>
-        /// <param name="convert">The string to attempt to convert</param>
-        /// <param name="slug">The formed slug - will be blank on failure</param>
-        /// <returns>true on success, false on failure</returns>
+        /// <remarks>
+        /// Conversion steps applied in order:
+        /// <list type="number">
+        ///   <item>CamelCase/PascalCase boundaries are split with a hyphen.</item>
+        ///   <item>Non-alphanumeric characters are replaced with hyphens.</item>
+        ///   <item>Consecutive hyphens are collapsed to a single hyphen.</item>
+        ///   <item>The result is validated against the slug pattern.</item>
+        /// </list>
+        /// </remarks>
+        /// <param name="convert">The string to attempt to convert.</param>
+        /// <param name="slug">The formed slug on success; <see cref="string.Empty"/> on failure.</param>
+        /// <returns>True if a valid slug was produced; false if the input cannot be converted.</returns>
         public static bool TryToConvertToSlug(string? convert, out string slug)
         {
-            //It's most certainly not going to work
             if (string.IsNullOrWhiteSpace(convert))
             {
                 slug = string.Empty;
                 return false;
             }
-            
-            //Convert camel case to something slug safe
+
+            // Split CamelCase/PascalCase boundaries with a hyphen
             var converting = char.ToLower(convert[0]).ToString();
             converting += UpperCaseMatchRegex().Replace(convert[1..], match => "-" + char.ToLower(match.Value[0]));
-            
-            //Replace non-alphanumeric with dashes
+
+            // Replace non-alphanumeric characters with hyphens
             converting = UrlSlugReplaceRegex().Replace(converting, "-");
 
-            //Replace multiple dashes with a single dash
+            // Collapse multiple consecutive hyphens to a single hyphen
             converting = MultipleDashesReplacementRegex().Replace(converting, "-");
 
-            //Validate
             if (IsValidUriSlug(converting))
             {
-                //It's okay.  Give the new slug
                 slug = converting;
                 return true;
             }
 
-            //Something is very wrong
             slug = string.Empty;
             return false;
         }
@@ -125,64 +145,106 @@ public static partial class Utilities
         #endregion
 
         /// <summary>
-        /// Build a full url, url encoding the contents of the query object
+        /// Builds a full URL by appending URL-encoded query parameters to a base URL.
         /// </summary>
-        /// <param name="baseUrl"></param>
-        /// <param name="queryObject"></param>
-        /// <returns></returns>
+        /// <remarks>
+        /// Bracket notation (<c>key[]</c>) is preserved — <c>%5B%5D</c> sequences are restored
+        /// to literal <c>[]</c> to support array-style query parameters
+        /// (e.g. <c>ids[]=1&amp;ids[]=2</c>).
+        /// </remarks>
+        /// <param name="baseUrl">The base URL to append the query string to.</param>
+        /// <param name="queryObject">The query parameters as a dictionary. Keys are unique.</param>
+        /// <returns>The fully constructed URL with encoded query string.</returns>
         public static string BuildUrl(string baseUrl, IDictionary<string, string> queryObject)
             => BuildUrl(baseUrl, queryObject.ToArray());
-        
+
         /// <summary>
-        /// Build a full url, url encoding the contents of the query object
+        /// Builds a full URL by appending URL-encoded query parameters to a base URL.
         /// </summary>
-        /// <param name="baseUrl"></param>
-        /// <param name="queryObject"></param>
-        /// <returns></returns>
+        /// <remarks>
+        /// Accepts an enumerable of key-value pairs to allow duplicate keys, which is useful
+        /// for array-style query parameters (e.g. <c>ids[]=1&amp;ids[]=2</c>).
+        /// Bracket notation (<c>key[]</c>) is preserved — <c>%5B%5D</c> sequences are restored
+        /// to literal <c>[]</c> regardless of hex casing.
+        /// </remarks>
+        /// <param name="baseUrl">The base URL to append the query string to.</param>
+        /// <param name="queryObject">The query parameters as key-value pairs. Duplicate keys are permitted.</param>
+        /// <returns>The fully constructed URL with encoded query string.</returns>
         public static string BuildUrl(string baseUrl, IEnumerable<KeyValuePair<string, string>> queryObject)
         {
             var s = new StringBuilder(baseUrl);
             var first = true;
-            foreach (var (key, member) in queryObject)
+            foreach (var (key, value) in queryObject)
             {
                 var k = HttpUtility.UrlEncode(key);
-                if (k.Contains("%5b%5d")) k = k.Replace("%5b%5d", "[]");
-                var v = HttpUtility.UrlEncode(member);
-                s.Append(first ? "?" : "&");
+
+                // Restore bracket notation for array-style params (e.g. ids[]=1&ids[]=2).
+                // HttpUtility.UrlEncode may produce either %5b%5d or %5B%5D depending on runtime —
+                // replace case-insensitively to handle both.
+                if (k.Contains("%5b%5d", StringComparison.OrdinalIgnoreCase))
+                    k = k.Replace("%5b%5d", "[]", StringComparison.OrdinalIgnoreCase);
+
+                var v = HttpUtility.UrlEncode(value);
+                s.Append(first ? '?' : '&');
                 first = false;
-                s.Append($"{k}={v}");
+                s.Append(k).Append('=').Append(v);
             }
 
             return s.ToString();
         }
 
-
         /// <summary>
-        /// Checks if the Top-level domain within the host of the given URI is a valid domain
+        /// Checks whether the top-level domain within the host of the given URI is a recognised TLD.
         /// </summary>
-        /// <param name="uri">The Uri resource to check against (ASCII/punycode)</param>
-        /// <param name="okayIfNotDnsType">This is for catching edge cases like disallowing ipv4 hosts to get through.  default = true</param>
-        /// <remarks>File pulled from https://data.iana.org/TLD/tlds-alpha-by-domain.txt</remarks>
-        /// <returns></returns>
+        /// <remarks>
+        /// Validates against the IANA TLD list (<see href="https://data.iana.org/TLD/tlds-alpha-by-domain.txt"/>).
+        /// Non-DNS host types (IPv4, IPv6) are handled by <paramref name="okayIfNotDnsType"/>.
+        /// </remarks>
+        /// <param name="uri">The URI to check. Host must be in ASCII/Punycode form.</param>
+        /// <param name="okayIfNotDnsType">
+        /// Whether to return true for non-DNS host types (e.g. IPv4, IPv6). Defaults to true.
+        /// Set to false to reject IP-addressed URIs explicitly.
+        /// </param>
+        /// <returns>True if the TLD is valid or the host is a non-DNS type and <paramref name="okayIfNotDnsType"/> is true; otherwise, false.</returns>
         public static bool HasValidTopLevelDomain(Uri uri, bool okayIfNotDnsType = true)
         {
-            if (uri.HostNameType is not UriHostNameType.Dns || string.IsNullOrEmpty(uri.Host)) return okayIfNotDnsType;
+            if (uri.HostNameType is not UriHostNameType.Dns || string.IsNullOrEmpty(uri.Host))
+                return okayIfNotDnsType;
+
             var tld = uri.DnsSafeHost.Split('.')[^1].ToUpperInvariant();
             if (string.IsNullOrWhiteSpace(tld)) return false;
-            //NOTE: I do want this to throw an exception if the file isn't there for some reason
+
+            // NOTE: intentionally throws if Tlds.Domains is unavailable — a missing TLD list
+            // is a configuration error, not a validation failure, and must not silently pass.
             using var reader = new StringReader(Tlds.Domains);
-            while (reader.ReadLine() is { } line) if (!line.StartsWith('#') && line == tld) return true;
+            while (reader.ReadLine() is { } line)
+                if (!line.StartsWith('#') && line == tld) return true;
+
             return false;
         }
 
         /// <summary>
         /// Attempts to normalize and convert a domain name to its Punycode and Unicode representations.
         /// </summary>
-        /// <param name="inputDomain">The input domain name to be normalized and converted.</param>
-        /// <param name="normalizedDomainPunycode">The output parameter where the Punycode representation of the normalized domain is stored if successful, otherwise null.</param>
-        /// <param name="normalizedDomainUnicode">The output parameter where the Unicode representation of the normalized domain is stored if successful, otherwise null.</param>
-        /// <param name="skipInternalValidation">If true, skips internal validation of the domain's validity.</param>
-        /// <returns>A boolean indicating whether the normalization and conversion were successful.</returns>
+        /// <remarks>
+        /// Normalization steps applied before conversion:
+        /// <list type="bullet">
+        ///   <item>Leading/trailing whitespace is trimmed.</item>
+        ///   <item>Leading/trailing dots are trimmed.</item>
+        ///   <item>The result is lowercased.</item>
+        /// </list>
+        /// </remarks>
+        /// <param name="inputDomain">The domain name to normalize and convert. Can be null or empty.</param>
+        /// <param name="normalizedDomainPunycode">
+        /// The Punycode (ASCII-compatible encoding) representation if successful; otherwise, null.
+        /// </param>
+        /// <param name="normalizedDomainUnicode">
+        /// The Unicode representation if successful; otherwise, null.
+        /// </param>
+        /// <param name="skipInternalValidation">
+        /// If true, skips TLD validation. Useful for internal or custom domains.
+        /// </param>
+        /// <returns>True if normalization and conversion succeeded; otherwise, false.</returns>
         public static bool TryNormalizeAndPunycodeDomain(
             string? inputDomain,
             [NotNullWhen(true)] out string? normalizedDomainPunycode,
@@ -195,29 +257,31 @@ public static partial class Utilities
                 normalizedDomainUnicode = null;
                 return false;
             }
-            
+
             var proposedUnicode = inputDomain.Trim().Trim('.');
             var idn = new IdnMapping();
+
             try
             {
                 normalizedDomainPunycode = idn.GetAscii(proposedUnicode).ToLowerInvariant();
             }
-            catch
+            catch (ArgumentException)
             {
+                // Input is not a valid domain name — malformed labels, illegal characters, etc.
                 normalizedDomainPunycode = null;
                 normalizedDomainUnicode = null;
                 return false;
             }
-            
-            var matches = PunycodeDomainMatchRegex().IsMatch(normalizedDomainPunycode);
-            if (!matches)
+
+            if (!PunycodeDomainMatchRegex().IsMatch(normalizedDomainPunycode))
             {
                 normalizedDomainPunycode = null;
                 normalizedDomainUnicode = null;
                 return false;
             }
 
-            if (!skipInternalValidation && !HasValidTopLevelDomain(new Uri($"https://{normalizedDomainPunycode}")))
+            if (!skipInternalValidation &&
+                !HasValidTopLevelDomain(new Uri($"https://{normalizedDomainPunycode}")))
             {
                 normalizedDomainPunycode = null;
                 normalizedDomainUnicode = null;
@@ -229,34 +293,36 @@ public static partial class Utilities
                 normalizedDomainUnicode = idn.GetUnicode(normalizedDomainPunycode);
                 return true;
             }
-            catch
+            catch (ArgumentException)
             {
+                // Punycode produced by GetAscii could not be round-tripped back to Unicode —
+                // treat as invalid rather than propagating a corrupt result.
                 normalizedDomainPunycode = null;
                 normalizedDomainUnicode = null;
                 return false;
             }
-
         }
     }
-    
-    [GeneratedRegex(@"^([a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?$", RegexOptions.IgnoreCase)]
+
+    [GeneratedRegex(@"^([a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?$",
+        RegexOptions.IgnoreCase)]
     private static partial Regex PunycodeDomainMatchRegex();
-    
+
     [GeneratedRegex("[A-Z]")]
     private static partial Regex UpperCaseMatchRegex();
-    
+
     [GeneratedRegex("\\-{2,}")]
     private static partial Regex MultipleDashesReplacementRegex();
-    
+
     [GeneratedRegex("^[a-zA-Z][-a-zA-Z0-9_]*$")]
     private static partial Regex UrlSegmentRegex();
-    
+
     [GeneratedRegex(@"^[a-zA-Z0-9\-\._~!$&'()*+,;=:]+$")]
     private static partial Regex UserInfoRegex();
-    
+
     [GeneratedRegex("^[a-z0-9]+(?:-[a-z0-9]+)*$")]
     private static partial Regex UrlSlugRegex();
-    
+
     [GeneratedRegex("[^a-z0-9\\-]")]
     private static partial Regex UrlSlugReplaceRegex();
 

--- a/FriendToNetWebDevelopers.MicroUtilities/Utility/VariableUtilities.cs
+++ b/FriendToNetWebDevelopers.MicroUtilities/Utility/VariableUtilities.cs
@@ -9,15 +9,30 @@ public static partial class Utilities
 {
     public static class Variable
     {
+        // Minor words that should not be capitalised in title case unless they are
+        // the first or last word. Based on standard English title-case conventions
+        // (Chicago Manual of Style / AP style).
+        private static readonly HashSet<string> TitleCaseMinorWords = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "a", "an", "the",
+            "and", "but", "for", "or", "nor",
+            "at", "by", "in", "of", "on", "to", "with", "from"
+        };
+
         /// <summary>
-        /// Determines the format type of a given variable name based on its structure and characters.
+        /// Determines the naming convention of a given variable name based on its structure and characters.
         /// </summary>
-        /// <param name="variableName">The variable name whose format is to be determined.</param>
-        /// <returns>A <see cref="ResultsVariableNameTypeEnum"/> value indicating the format type of the variable name. Returns <c>Unknown</c> if the format cannot be determined or the variable name is invalid.</returns>
+        /// <param name="variableName">The variable name to analyse.</param>
+        /// <returns>
+        /// A <see cref="ResultsVariableNameTypeEnum"/> value indicating the detected convention.
+        /// Returns <see cref="ResultsVariableNameTypeEnum.Words"/> for space-separated or mixed input
+        /// that does not match a variable naming convention.
+        /// Returns <see cref="ResultsVariableNameTypeEnum.Unknown"/> if the input is null, whitespace,
+        /// or contains no letters or digits.
+        /// </returns>
         public static ResultsVariableNameTypeEnum GetVariableFormat(string variableName)
         {
             if (string.IsNullOrWhiteSpace(variableName)) return ResultsVariableNameTypeEnum.Unknown;
-
             if (!variableName.Any(char.IsLetterOrDigit)) return ResultsVariableNameTypeEnum.Unknown;
 
             var isPotentialVariable = char.IsLetter(variableName[0]) &&
@@ -70,11 +85,23 @@ public static partial class Utilities
         }
 
         /// <summary>
-        /// Tries to determine the format type of a given variable name based on its structure and characters.
+        /// Attempts to determine the naming convention of a given variable name.
         /// </summary>
-        /// <param name="variableName">The variable name whose format is to be analyzed.</param>
-        /// <param name="type">When this method returns, contains the determined format type of the variable. If the format is unknown or the input is invalid, this will be set to <c>ResultsVariableNameTypeEnum.Unknown</c>.</param>
-        /// <returns><c>true</c> if the format of the variable name is identified successfully; otherwise, <c>false</c>.</returns>
+        /// <remarks>
+        /// Returns <c>false</c> for <see cref="ResultsVariableNameTypeEnum.Words"/> and
+        /// <see cref="ResultsVariableNameTypeEnum.Unknown"/>, even though <c>Words</c> input
+        /// is accepted by <see cref="ConvertTo"/> and <see cref="TryConvertTo"/>. If you need
+        /// to convert a space-separated or freeform string, call those methods directly rather
+        /// than gating on this one.
+        /// </remarks>
+        /// <param name="variableName">The variable name to analyse.</param>
+        /// <param name="type">
+        /// The detected naming convention, or <see cref="ResultsVariableNameTypeEnum.Unknown"/>
+        /// if detection failed.
+        /// </param>
+        /// <returns>
+        /// <c>true</c> if a specific naming convention was identified; otherwise, <c>false</c>.
+        /// </returns>
         public static bool TryGetVariableFormat(string variableName, out ResultsVariableNameTypeEnum type)
         {
             type = GetVariableFormat(variableName);
@@ -82,21 +109,40 @@ public static partial class Utilities
         }
 
         /// <summary>
-        /// Converts the format of a given variable name to a specified target format.
+        /// Converts a variable name from its detected naming convention to the specified target convention.
         /// </summary>
-        /// <param name="variableName">The variable name to be converted.</param>
-        /// <param name="targetType">The target format type to which the variable name should be converted.</param>
-        /// <returns>A tuple containing the converted variable name, the original format type, and the target format type.</returns>
-        /// <exception cref="ArgumentException">Thrown when the target format type is <c>Unknown</c>.</exception>
-        /// <exception cref="NotAValidVariableNameException">Thrown when the provided variable name is invalid or its format cannot be determined.</exception>
-        public static (string result, ResultsVariableNameTypeEnum from, RequestedVariableNameTypeEnum to) ConvertTo(string variableName,
+        /// <remarks>
+        /// Space-separated or mixed input (<see cref="ResultsVariableNameTypeEnum.Words"/>) is accepted
+        /// and will be split on non-alphanumeric boundaries before conversion.
+        /// <para>
+        /// <b>Acronym casing:</b> When converting to CamelCase, PascalCase, or similar mixed-case formats,
+        /// the tail of each word is lowercased. This means <c>HTMLParser</c> converts to
+        /// <c>htmlParser</c> (camelCase) or <c>HtmlParser</c> (PascalCase) rather than preserving
+        /// the original acronym casing. This is consistent with common conventions (e.g. .NET's own
+        /// <c>HtmlEncoder</c>, <c>JsonSerializer</c>) and is intentional.
+        /// </para>
+        /// <para>
+        /// <b>Unicase / TrollCase inputs:</b> Word boundaries cannot be recovered from all-lower or
+        /// all-upper input. Such inputs are treated as a single word.
+        /// </para>
+        /// </remarks>
+        /// <param name="variableName">The variable name to convert.</param>
+        /// <param name="targetType">The target naming convention.</param>
+        /// <returns>
+        /// A tuple of the converted name, the detected source convention, and the target convention.
+        /// </returns>
+        /// <exception cref="NotAValidVariableNameException">
+        /// Thrown when the input is null, empty, or contains no recognisable letters or digits.
+        /// </exception>
+        public static (string result, ResultsVariableNameTypeEnum from, RequestedVariableNameTypeEnum to) ConvertTo(
+            string variableName,
             RequestedVariableNameTypeEnum targetType)
         {
             var from = GetVariableFormat(variableName);
             if (from == ResultsVariableNameTypeEnum.Unknown)
                 throw new NotAValidVariableNameException(variableName);
 
-            if (from.ToString() == targetType.ToString()) return (variableName, from, targetType);
+            if (IsSameFormat(from, targetType)) return (variableName, from, targetType);
 
             var words = _getWords(variableName, from);
             var result = _internalConvert(words, targetType);
@@ -104,12 +150,18 @@ public static partial class Utilities
         }
 
         /// <summary>
-        /// Attempts to convert the given variable name to the specified format type.
+        /// Attempts to convert a variable name from its detected naming convention to the specified target convention.
         /// </summary>
-        /// <param name="variableName">The variable name to be converted.</param>
-        /// <param name="targetType">The target format type to which the variable name should be converted.</param>
-        /// <param name="output">An output tuple containing the converted variable name, the original format type, and the target format type.</param>
-        /// <returns>A boolean value indicating whether the conversion was successful. Returns <c>false</c> if the target type is <c>Unknown</c>, if the input variable name format cannot be determined, or if the conversion fails.</returns>
+        /// <param name="variableName">The variable name to convert.</param>
+        /// <param name="targetType">The target naming convention.</param>
+        /// <param name="output">
+        /// A tuple of the converted name, the detected source convention, and the target convention.
+        /// Contains default values if this method returns false.
+        /// </param>
+        /// <returns>
+        /// <c>true</c> if conversion succeeded; <c>false</c> if the input is unrecognisable
+        /// or conversion fails.
+        /// </returns>
         public static bool TryConvertTo(string variableName, RequestedVariableNameTypeEnum targetType,
             out (string result, ResultsVariableNameTypeEnum from, RequestedVariableNameTypeEnum to) output)
         {
@@ -124,296 +176,211 @@ public static partial class Utilities
                 output = (result, currentType, targetType);
                 return true;
             }
-            catch
+            catch (ArgumentException)
             {
                 return false;
             }
         }
 
-        /// <summary>
-        /// Converts a variable name to camelCase format.
-        /// </summary>
-        /// <param name="variableName">The variable name to be converted.</param>
-        /// <returns>A tuple containing the converted variable name, the original variable name type, and the target variable name type.
-        /// The original variable name type is determined during the conversion process.</returns>
+        /// <summary>Converts a variable name to camelCase.</summary>
+        /// <inheritdoc cref="ConvertTo"/>
         public static (string result, ResultsVariableNameTypeEnum from, RequestedVariableNameTypeEnum to)
             ConvertToCamelCase(string variableName) => ConvertTo(variableName, RequestedVariableNameTypeEnum.CamelCase);
 
-        /// <summary>
-        /// Attempts to convert a variable name to camelCase format while providing detailed transformation information.
-        /// </summary>
-        /// <param name="variableName">The variable name to be converted to camelCase format.</param>
-        /// <param name="output">
-        /// An output tuple containing the converted variable name as <c>result</c>,
-        /// the original format of the variable name as <c>from</c>,
-        /// and the target format (<see cref="RequestedVariableNameTypeEnum.CamelCase"/>) as <c>to</c>.
-        /// </param>
-        /// <returns>
-        /// <c>true</c> if the conversion to camelCase is successful; otherwise, <c>false</c>.
-        /// </returns>
+        /// <summary>Attempts to convert a variable name to camelCase.</summary>
+        /// <inheritdoc cref="TryConvertTo"/>
         public static bool TryConvertToCamelCase(string variableName,
             out (string result, ResultsVariableNameTypeEnum from, RequestedVariableNameTypeEnum to) output) =>
             TryConvertTo(variableName, RequestedVariableNameTypeEnum.CamelCase, out output);
 
-        /// <summary>
-        /// Converts the given variable name to PascalCase format.
-        /// </summary>
-        /// <param name="variableName">The variable name to convert to PascalCase.</param>
-        /// <returns>A tuple containing the converted variable name, the original format as a <see cref="ResultsVariableNameTypeEnum"/> value, and the target format as <c>PascalCase</c>.</returns>
+        /// <summary>Converts a variable name to PascalCase.</summary>
+        /// <inheritdoc cref="ConvertTo"/>
         public static (string result, ResultsVariableNameTypeEnum from, RequestedVariableNameTypeEnum to)
-            ConvertToPascalCase(string variableName) => ConvertTo(variableName, RequestedVariableNameTypeEnum.PascalCase);
+            ConvertToPascalCase(string variableName) =>
+            ConvertTo(variableName, RequestedVariableNameTypeEnum.PascalCase);
 
-        /// <summary>
-        /// Attempts to convert a given variable name to PascalCase format.
-        /// </summary>
-        /// <param name="variableName">The variable name to be converted.</param>
-        /// <param name="output">
-        /// A tuple containing the converted variable name, the original variable name format,
-        /// and the target format. If conversion fails, the tuple values will be set to their defaults.
-        /// </param>
-        /// <returns>
-        /// <c>true</c> if the variable name is successfully converted to PascalCase; otherwise, <c>false</c>.
-        /// </returns>
+        /// <summary>Attempts to convert a variable name to PascalCase.</summary>
+        /// <inheritdoc cref="TryConvertTo"/>
         public static bool TryConvertToPascalCase(string variableName,
             out (string result, ResultsVariableNameTypeEnum from, RequestedVariableNameTypeEnum to) output) =>
             TryConvertTo(variableName, RequestedVariableNameTypeEnum.PascalCase, out output);
 
-        /// <summary>
-        /// Converts a given variable name to snake_case format.
-        /// </summary>
-        /// <param name="variableName">The variable name to be converted to snake_case.</param>
-        /// <returns>A tuple containing the converted variable name as <c>result</c>,
-        /// the original variable name format as <c>from</c>, and the target format
-        /// (<see cref="RequestedVariableNameTypeEnum.SnakeCase"/>) as <c>to</c>.</returns>
+        /// <summary>Converts a variable name to snake_case.</summary>
+        /// <inheritdoc cref="ConvertTo"/>
         public static (string result, ResultsVariableNameTypeEnum from, RequestedVariableNameTypeEnum to)
-            ConvertToSnakeCase(string variableName) => ConvertTo(variableName, RequestedVariableNameTypeEnum.SnakeCase);
+            ConvertToSnakeCase(string variableName) =>
+            ConvertTo(variableName, RequestedVariableNameTypeEnum.SnakeCase);
 
-        /// <summary>
-        /// Attempts to convert the given variable name into snake_case format.
-        /// </summary>
-        /// <param name="variableName">The variable name to be converted.</param>
-        /// <param name="output">An output tuple containing the converted variable name, the original format type, and the target format type.</param>
-        /// <returns><c>true</c> if the conversion is successful; otherwise, <c>false</c>.</returns>
+        /// <summary>Attempts to convert a variable name to snake_case.</summary>
+        /// <inheritdoc cref="TryConvertTo"/>
         public static bool TryConvertToSnakeCase(string variableName,
             out (string result, ResultsVariableNameTypeEnum from, RequestedVariableNameTypeEnum to) output) =>
             TryConvertTo(variableName, RequestedVariableNameTypeEnum.SnakeCase, out output);
 
-        /// <summary>
-        /// Converts the given variable name to Screaming Snake Case format.
-        /// </summary>
-        /// <param name="variableName">The variable name to be transformed into Screaming Snake Case.</param>
-        /// <returns>A tuple containing the converted variable name, the original variable's naming format, and the target naming format (Screaming Snake Case).</returns>
+        /// <summary>Converts a variable name to SCREAMING_SNAKE_CASE.</summary>
+        /// <inheritdoc cref="ConvertTo"/>
         public static (string result, ResultsVariableNameTypeEnum from, RequestedVariableNameTypeEnum to)
             ConvertToScreamingSnakeCase(string variableName) =>
             ConvertTo(variableName, RequestedVariableNameTypeEnum.ScreamingSnakeCase);
 
-        /// <summary>
-        /// Attempts to convert a given variable name to the ScreamingSnakeCase format.
-        /// </summary>
-        /// <param name="variableName">The variable name to be converted to ScreamingSnakeCase.</param>
-        /// <param name="output">
-        /// An output tuple containing the converted variable name in ScreamingSnakeCase format,
-        /// the original format of the variable name, and the target format (ScreamingSnakeCase).
-        /// </param>
-        /// <returns>
-        /// A boolean value indicating whether the conversion was successful. Returns <c>true</c> if the conversion succeeded; otherwise, <c>false</c>.
-        /// </returns>
+        /// <summary>Attempts to convert a variable name to SCREAMING_SNAKE_CASE.</summary>
+        /// <inheritdoc cref="TryConvertTo"/>
         public static bool TryConvertToScreamingSnakeCase(string variableName,
             out (string result, ResultsVariableNameTypeEnum from, RequestedVariableNameTypeEnum to) output) =>
             TryConvertTo(variableName, RequestedVariableNameTypeEnum.ScreamingSnakeCase, out output);
 
-        /// <summary>
-        /// Converts the given variable name to kebab-case format.
-        /// </summary>
-        /// <param name="variableName">The variable name to be converted to kebab-case.</param>
-        /// <returns>A tuple containing the converted variable name in kebab-case, the original variable name format as a <see cref="ResultsVariableNameTypeEnum"/>, and the target format <see cref="RequestedVariableNameTypeEnum.KebabCase"/>.</returns>
+        /// <summary>Converts a variable name to kebab-case.</summary>
+        /// <inheritdoc cref="ConvertTo"/>
         public static (string result, ResultsVariableNameTypeEnum from, RequestedVariableNameTypeEnum to)
-            ConvertToKebabCase(string variableName) => ConvertTo(variableName, RequestedVariableNameTypeEnum.KebabCase);
+            ConvertToKebabCase(string variableName) =>
+            ConvertTo(variableName, RequestedVariableNameTypeEnum.KebabCase);
 
-        /// <summary>
-        /// Attempts to convert the provided variable name to kebab-case format.
-        /// </summary>
-        /// <param name="variableName">The variable name to be converted.</param>
-        /// <param name="output">
-        /// When this method returns, contains a tuple with the result string in kebab-case format,
-        /// the original format of the variable name, and the target format, if the conversion was successful.
-        /// Otherwise, it contains default values.
-        /// </param>
-        /// <returns>
-        /// <c>true</c> if the variable name was successfully converted to kebab-case; otherwise, <c>false</c>.
-        /// </returns>
+        /// <summary>Attempts to convert a variable name to kebab-case.</summary>
+        /// <inheritdoc cref="TryConvertTo"/>
         public static bool TryConvertToKebabCase(string variableName,
             out (string result, ResultsVariableNameTypeEnum from, RequestedVariableNameTypeEnum to) output) =>
             TryConvertTo(variableName, RequestedVariableNameTypeEnum.KebabCase, out output);
 
-        /// <summary>
-        /// Converts a variable name to TrainCase format while returning metadata about the conversion process.
-        /// </summary>
-        /// <param name="variableName">The variable name to be converted to TrainCase.</param>
-        /// <returns>A tuple containing the converted variable name in TrainCase format as <c>result</c>,
-        /// the original variable name format as <c>from</c>, and <c>to</c> as the target TrainCase format.</returns>
+        /// <summary>Converts a variable name to Train-Case.</summary>
+        /// <inheritdoc cref="ConvertTo"/>
         public static (string result, ResultsVariableNameTypeEnum from, RequestedVariableNameTypeEnum to)
-            ConvertToTrainCase(string variableName) => ConvertTo(variableName, RequestedVariableNameTypeEnum.TrainCase);
+            ConvertToTrainCase(string variableName) =>
+            ConvertTo(variableName, RequestedVariableNameTypeEnum.TrainCase);
 
-        /// <summary>
-        /// Attempts to convert the given variable name to TrainCase format.
-        /// </summary>
-        /// <param name="variableName">The variable name to be converted.</param>
-        /// <param name="output">
-        /// When this method returns, contains a tuple with the converted variable name,
-        /// the original format of the variable name, and the target format. This parameter
-        /// is passed uninitialized and will only contain valid data if the conversion succeeds.
-        /// </param>
-        /// <returns>
-        /// <c>true</c> if the variable name was successfully converted to TrainCase; otherwise, <c>false</c>.
-        /// </returns>
+        /// <summary>Attempts to convert a variable name to Train-Case.</summary>
+        /// <inheritdoc cref="TryConvertTo"/>
         public static bool TryConvertToTrainCase(string variableName,
             out (string result, ResultsVariableNameTypeEnum from, RequestedVariableNameTypeEnum to) output) =>
             TryConvertTo(variableName, RequestedVariableNameTypeEnum.TrainCase, out output);
 
-        /// <summary>
-        /// Converts a variable name to the Unicase format.
-        /// </summary>
-        /// <param name="variableName">The variable name to be converted to the Unicase format.</param>
-        /// <returns>A tuple containing the resulting Unicase-formatted variable name, the original variable name's format as a <see cref="ResultsVariableNameTypeEnum"/> value, and the target format type as <see cref="RequestedVariableNameTypeEnum.Unicase"/>.</returns>
+        /// <summary>Converts a variable name to unicase.</summary>
+        /// <inheritdoc cref="ConvertTo"/>
         public static (string result, ResultsVariableNameTypeEnum from, RequestedVariableNameTypeEnum to)
-            ConvertToUnicase(string variableName) => ConvertTo(variableName, RequestedVariableNameTypeEnum.Unicase);
+            ConvertToUnicase(string variableName) =>
+            ConvertTo(variableName, RequestedVariableNameTypeEnum.Unicase);
 
-        /// <summary>
-        /// Attempts to convert the specified variable name to the Unicase format.
-        /// </summary>
-        /// <param name="variableName">The variable name to convert to the Unicase format.</param>
-        /// <param name="output">
-        /// When this method returns, contains a tuple with the converted variable name,
-        /// the original format of the variable name, and the target format (Unicase), if the conversion was successful.
-        /// This parameter is passed uninitialized.
-        /// </param>
-        /// <returns>
-        /// <c>true</c> if the variable name was successfully converted to the Unicase format;
-        /// otherwise, <c>false</c>.
-        /// </returns>
+        /// <summary>Attempts to convert a variable name to unicase.</summary>
+        /// <inheritdoc cref="TryConvertTo"/>
         public static bool TryConvertToUnicase(string variableName,
             out (string result, ResultsVariableNameTypeEnum from, RequestedVariableNameTypeEnum to) output) =>
             TryConvertTo(variableName, RequestedVariableNameTypeEnum.Unicase, out output);
 
-        /// <summary>
-        /// Converts the given variable name to the TrollCase format.
-        /// </summary>
-        /// <param name="variableName">The variable name to be converted.</param>
-        /// <returns>A tuple containing the converted variable name in TrollCase format, the original format of the variable name, and the target format (TrollCase). Returns <c>Unknown</c> as the original format if it cannot be determined.</returns>
+        /// <summary>Converts a variable name to TROLLCASE.</summary>
+        /// <inheritdoc cref="ConvertTo"/>
         public static (string result, ResultsVariableNameTypeEnum from, RequestedVariableNameTypeEnum to)
-            ConvertToTrollCase(string variableName) => ConvertTo(variableName, RequestedVariableNameTypeEnum.TrollCase);
+            ConvertToTrollCase(string variableName) =>
+            ConvertTo(variableName, RequestedVariableNameTypeEnum.TrollCase);
 
-        /// <summary>
-        /// Attempts to convert the given variable name to TrollCase format.
-        /// </summary>
-        /// <param name="variableName">The variable name to be converted to TrollCase format.</param>
-        /// <param name="output">
-        /// An output tuple that contains the converted variable name, the original format type,
-        /// and the target format type (TrollCase).
-        /// </param>
-        /// <returns>
-        /// A boolean value indicating whether the conversion was successful. Returns <c>false</c>
-        /// if the conversion could not be performed, such as when the variable name is invalid
-        /// or unrecognized.
-        /// </returns>
+        /// <summary>Attempts to convert a variable name to TROLLCASE.</summary>
+        /// <inheritdoc cref="TryConvertTo"/>
         public static bool TryConvertToTrollCase(string variableName,
             out (string result, ResultsVariableNameTypeEnum from, RequestedVariableNameTypeEnum to) output) =>
             TryConvertTo(variableName, RequestedVariableNameTypeEnum.TrollCase, out output);
 
-        /// <summary>
-        /// Converts the given variable name to the TitleWords format.
-        /// </summary>
-        /// <param name="variableName">The variable name to be converted.</param>
-        /// <returns>A tuple containing the converted variable name in TitleWords format, the original format of the variable name, and the target format (TitleWords).</returns>
+        /// <summary>Converts a variable name to Title Words.</summary>
+        /// <inheritdoc cref="ConvertTo"/>
         public static (string result, ResultsVariableNameTypeEnum from, RequestedVariableNameTypeEnum to)
-            ConvertToTitleWords(string variableName) => ConvertTo(variableName, RequestedVariableNameTypeEnum.TitleWords);
+            ConvertToTitleWords(string variableName) =>
+            ConvertTo(variableName, RequestedVariableNameTypeEnum.TitleWords);
 
-        /// <summary>
-        /// Attempts to convert the given variable name to TitleWords format.
-        /// </summary>
-        /// <param name="variableName">The variable name to be converted to TitleWords format.</param>
-        /// <param name="output">
-        /// An output tuple that contains the converted variable name, the original format type,
-        /// and the target format type (TitleWords).
-        /// </param>
-        /// <returns>
-        /// A boolean value indicating whether the conversion was successful.
-        /// </returns>
+        /// <summary>Attempts to convert a variable name to Title Words.</summary>
+        /// <inheritdoc cref="TryConvertTo"/>
         public static bool TryConvertToTitleWords(string variableName,
             out (string result, ResultsVariableNameTypeEnum from, RequestedVariableNameTypeEnum to) output) =>
             TryConvertTo(variableName, RequestedVariableNameTypeEnum.TitleWords, out output);
 
-        /// <summary>
-        /// Converts the given variable name to the SentenceWords format.
-        /// </summary>
-        /// <param name="variableName">The variable name to be converted.</param>
-        /// <returns>A tuple containing the converted variable name in SentenceWords format, the original format of the variable name, and the target format (SentenceWords).</returns>
+        /// <summary>Converts a variable name to Sentence words.</summary>
+        /// <inheritdoc cref="ConvertTo"/>
         public static (string result, ResultsVariableNameTypeEnum from, RequestedVariableNameTypeEnum to)
-            ConvertToSentenceWords(string variableName) => ConvertTo(variableName, RequestedVariableNameTypeEnum.SentenceWords);
+            ConvertToSentenceWords(string variableName) =>
+            ConvertTo(variableName, RequestedVariableNameTypeEnum.SentenceWords);
 
-        /// <summary>
-        /// Attempts to convert the given variable name to SentenceWords format.
-        /// </summary>
-        /// <param name="variableName">The variable name to be converted to SentenceWords format.</param>
-        /// <param name="output">
-        /// An output tuple that contains the converted variable name, the original format type,
-        /// and the target format type (SentenceWords).
-        /// </param>
-        /// <returns>
-        /// A boolean value indicating whether the conversion was successful.
-        /// </returns>
+        /// <summary>Attempts to convert a variable name to Sentence words.</summary>
+        /// <inheritdoc cref="TryConvertTo"/>
         public static bool TryConvertToSentenceWords(string variableName,
             out (string result, ResultsVariableNameTypeEnum from, RequestedVariableNameTypeEnum to) output) =>
             TryConvertTo(variableName, RequestedVariableNameTypeEnum.SentenceWords, out output);
 
         /// <summary>
-        /// Gets a formatted variable name from an object's type name.
+        /// Gets a formatted variable name from an object instance's type.
         /// </summary>
-        /// <param name="obj">The object whose type name will be used.</param>
-        /// <param name="targetType">The desired variable name format (default is camelCase).</param>
+        /// <param name="obj">The object whose type name will be formatted.</param>
+        /// <param name="targetType">The target naming convention. Defaults to camelCase.</param>
         /// <returns>A formatted variable name string.</returns>
-        public static string GetVariableName(object obj, RequestedVariableNameTypeEnum targetType = RequestedVariableNameTypeEnum.CamelCase)
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="obj"/> is null.</exception>
+        public static string GetVariableName(object obj,
+            RequestedVariableNameTypeEnum targetType = RequestedVariableNameTypeEnum.CamelCase)
         {
-            return obj == null ? string.Empty : GetVariableName(obj.GetType(), targetType);
+            ArgumentNullException.ThrowIfNull(obj);
+            return GetVariableName(obj.GetType(), targetType);
         }
 
         /// <summary>
         /// Gets a formatted variable name from a type or member name.
         /// </summary>
         /// <param name="member">The member or type whose name will be used.</param>
-        /// <param name="targetType">The desired variable name format (default is camelCase).</param>
+        /// <param name="targetType">The target naming convention. Defaults to camelCase.</param>
         /// <returns>A formatted variable name string.</returns>
-        public static string GetVariableName(MemberInfo member, RequestedVariableNameTypeEnum targetType = RequestedVariableNameTypeEnum.CamelCase)
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="member"/> is null.</exception>
+        public static string GetVariableName(MemberInfo member,
+            RequestedVariableNameTypeEnum targetType = RequestedVariableNameTypeEnum.CamelCase)
         {
-            if (member == null) return string.Empty;
+            ArgumentNullException.ThrowIfNull(member);
+
             var name = member.Name;
+
+            // Strip generic arity suffix (e.g. "List`1" → "List")
             if (name.Contains('`'))
-            {
-                name = name.Substring(0, name.IndexOf('`'));
-            }
+                name = name[..name.IndexOf('`')];
+
             return ConvertTo(name, targetType).result;
         }
 
         /// <summary>
-        /// Gets a formatted class name from an object's type.
+        /// Gets a PascalCase class name from an object instance's type.
         /// </summary>
         /// <param name="obj">The object whose type name will be used.</param>
         /// <returns>A PascalCase formatted class name string.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="obj"/> is null.</exception>
         public static string GetClassName(object obj)
         {
-            return obj == null ? string.Empty : GetClassName(obj.GetType());
+            ArgumentNullException.ThrowIfNull(obj);
+            return GetClassName(obj.GetType());
         }
 
         /// <summary>
-        /// Gets a formatted class name from a type.
+        /// Gets a PascalCase class name from a type.
         /// </summary>
         /// <param name="type">The type whose name will be used.</param>
         /// <returns>A PascalCase formatted class name string.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="type"/> is null.</exception>
         public static string GetClassName(Type type)
         {
+            ArgumentNullException.ThrowIfNull(type);
             return GetVariableName(type, RequestedVariableNameTypeEnum.PascalCase);
         }
+
+        /// <summary>
+        /// Maps a <see cref="ResultsVariableNameTypeEnum"/> to its equivalent
+        /// <see cref="RequestedVariableNameTypeEnum"/> and checks whether it matches
+        /// <paramref name="to"/>. Used to short-circuit conversion when source and
+        /// target are the same format, without relying on fragile string comparisons
+        /// across two separate enum types.
+        /// </summary>
+        private static bool IsSameFormat(ResultsVariableNameTypeEnum from, RequestedVariableNameTypeEnum to) =>
+            from switch
+            {
+                ResultsVariableNameTypeEnum.CamelCase => to == RequestedVariableNameTypeEnum.CamelCase,
+                ResultsVariableNameTypeEnum.PascalCase => to == RequestedVariableNameTypeEnum.PascalCase,
+                ResultsVariableNameTypeEnum.SnakeCase => to == RequestedVariableNameTypeEnum.SnakeCase,
+                ResultsVariableNameTypeEnum.ScreamingSnakeCase =>
+                    to == RequestedVariableNameTypeEnum.ScreamingSnakeCase,
+                ResultsVariableNameTypeEnum.KebabCase => to == RequestedVariableNameTypeEnum.KebabCase,
+                ResultsVariableNameTypeEnum.TrainCase => to == RequestedVariableNameTypeEnum.TrainCase,
+                ResultsVariableNameTypeEnum.Unicase => to == RequestedVariableNameTypeEnum.Unicase,
+                ResultsVariableNameTypeEnum.TrollCase => to == RequestedVariableNameTypeEnum.TrollCase,
+                _ => false
+            };
 
         private static string[] _getWords(string variableName, ResultsVariableNameTypeEnum type)
         {
@@ -422,69 +389,101 @@ public static partial class Utilities
                 case ResultsVariableNameTypeEnum.SnakeCase:
                 case ResultsVariableNameTypeEnum.ScreamingSnakeCase:
                     return variableName.Split('_', StringSplitOptions.RemoveEmptyEntries);
+
                 case ResultsVariableNameTypeEnum.KebabCase:
                 case ResultsVariableNameTypeEnum.TrainCase:
                     return variableName.Split('-', StringSplitOptions.RemoveEmptyEntries);
+
                 case ResultsVariableNameTypeEnum.CamelCase:
                 case ResultsVariableNameTypeEnum.PascalCase:
-                    return Regex.Split(variableName, @"(?=[A-Z])").Where(s => !string.IsNullOrEmpty(s)).ToArray();
+                    // Split on word boundaries, correctly handling consecutive uppercase runs
+                    // (acronyms) by keeping them together:
+                    //   "HTMLParser"    → ["HTML", "Parser"]
+                    //   "parseHTMLDoc"  → ["parse", "HTML", "Doc"]
+                    //   "MyClassName"   → ["My", "Class", "Name"]
+                    // Pattern explanation:
+                    //   (?<=[a-z0-9])(?=[A-Z])     — split before an uppercase that follows a lowercase/digit
+                    //   (?<=[A-Z])(?=[A-Z][a-z])   — split before the last uppercase in a run (e.g. "HTMLParser" → "HTML|Parser")
+                    return PascalSplitRegex().Split(variableName)
+                        .Where(s => !string.IsNullOrEmpty(s))
+                        .ToArray();
+
                 case ResultsVariableNameTypeEnum.Words:
                     return Regex.Split(variableName, @"[^a-zA-Z0-9]+")
                         .Where(s => !string.IsNullOrEmpty(s))
-                        .SelectMany(p => Regex.Split(p, @"(?=[A-Z])"))
+                        .SelectMany(p => PascalSplitRegex().Split(p))
                         .Where(s => !string.IsNullOrEmpty(s))
                         .ToArray();
+
                 case ResultsVariableNameTypeEnum.Unicase:
                 case ResultsVariableNameTypeEnum.TrollCase:
                 default:
+                    // Word boundaries are unrecoverable from all-lower or all-upper input.
+                    // Treated as a single word.
                     return [variableName];
             }
         }
-
-        private static readonly string[] TitleCaseMinorWords =
-        [
-            "a", "an", "the", 
-            "and", "but", "for", "or", "nor", 
-            "at", "by", "in", "of", "on", "to", "with", "from"
-        ];
 
         private static string _internalConvert(string[] words, RequestedVariableNameTypeEnum targetType)
         {
             switch (targetType)
             {
                 case RequestedVariableNameTypeEnum.CamelCase:
-                    return words[0].ToLower() +
-                           string.Concat(words.Skip(1).Select(w => char.ToUpper(w[0]) + w[1..].ToLower()));
+                    return words[0].ToLowerInvariant() +
+                           string.Concat(words.Skip(1).Select(w => char.ToUpperInvariant(w[0]) + w[1..].ToLowerInvariant()));
+
                 case RequestedVariableNameTypeEnum.PascalCase:
-                    return string.Concat(words.Select(w => char.ToUpper(w[0]) + w[1..].ToLower()));
+                    return string.Concat(words.Select(w => char.ToUpperInvariant(w[0]) + w[1..].ToLowerInvariant()));
+
                 case RequestedVariableNameTypeEnum.SnakeCase:
-                    return string.Join("_", words.Select(w => w.ToLower()));
+                    return string.Join("_", words.Select(w => w.ToLowerInvariant()));
+
                 case RequestedVariableNameTypeEnum.ScreamingSnakeCase:
-                    return string.Join("_", words.Select(w => w.ToUpper()));
+                    return string.Join("_", words.Select(w => w.ToUpperInvariant()));
+
                 case RequestedVariableNameTypeEnum.KebabCase:
-                    return string.Join("-", words.Select(w => w.ToLower()));
+                    return string.Join("-", words.Select(w => w.ToLowerInvariant()));
+
                 case RequestedVariableNameTypeEnum.TrainCase:
-                    return string.Join("-", words.Select(w => char.ToUpper(w[0]) + w[1..].ToLower()));
+                    return string.Join("-",
+                        words.Select(w => char.ToUpperInvariant(w[0]) + w[1..].ToLowerInvariant()));
+
                 case RequestedVariableNameTypeEnum.Unicase:
-                    return string.Concat(words).ToLower();
+                    return string.Concat(words).ToLowerInvariant();
+
                 case RequestedVariableNameTypeEnum.TrollCase:
-                    return string.Concat(words).ToUpper();
+                    return string.Concat(words).ToUpperInvariant();
+
                 case RequestedVariableNameTypeEnum.TitleWords:
                     return string.Join(" ", words.Select((w, i) =>
                     {
-                        var lower = w.ToLower();
+                        var lower = w.ToLowerInvariant();
+                        // Minor words are lowercased unless they are first or last
                         if (i > 0 && i < words.Length - 1 && TitleCaseMinorWords.Contains(lower))
-                        {
                             return lower;
-                        }
-                        return char.ToUpper(lower[0]) + lower[1..];
+                        return char.ToUpperInvariant(lower[0]) + lower[1..];
                     }));
+
                 case RequestedVariableNameTypeEnum.SentenceWords:
-                    return char.ToUpper(words[0][0]) + words[0][1..].ToLower() + 
-                           (words.Length > 1 ? " " + string.Join(" ", words.Skip(1).Select(w => w.ToLower())) : "");
+                    return char.ToUpperInvariant(words[0][0]) + words[0][1..].ToLowerInvariant() +
+                           (words.Length > 1
+                               ? " " + string.Join(" ", words.Skip(1).Select(w => w.ToLowerInvariant()))
+                               : "");
+
                 default:
                     return string.Concat(words);
             }
         }
     }
+
+    /// <summary>
+    /// Splits a PascalCase or camelCase string on word boundaries while keeping
+    /// consecutive-uppercase runs (acronyms) together as a single token.
+    /// Examples:
+    ///   "HTMLParser"   → ["HTML", "Parser"]
+    ///   "parseHTMLDoc" → ["parse", "HTML", "Doc"]
+    ///   "MyClass"      → ["My", "Class"]
+    /// </summary>
+    [GeneratedRegex(@"(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])")]
+    private static partial Regex PascalSplitRegex();
 }

--- a/FriendToNetWebDevelopers.MicroUtilities/Utility/YoutubeUtilities.cs
+++ b/FriendToNetWebDevelopers.MicroUtilities/Utility/YoutubeUtilities.cs
@@ -7,71 +7,79 @@ namespace FriendToNetWebDevelopers.MicroUtilities;
 public static partial class Utilities
 {
     /// <summary>
-    /// Used to handle miscellaneous youtube-related url tasks.<br/>
-    /// Makes heavy use of Uri building and validation.  Should make life more difficult for a hostile actor. 
+    /// Handles YouTube-related URL tasks including ID validation, thumbnail URL generation,
+    /// and embed URL generation.
     /// </summary>
+    /// <remarks>
+    /// Makes deliberate use of URI building and validation to harden against malformed or
+    /// hostile input.
+    /// </remarks>
     public static partial class Youtube
     {
         /// <summary>
-        /// Gets the default size thumbnail
+        /// Gets the HQ default thumbnail URL for the specified YouTube video.
         /// </summary>
-        /// <param name="youtubeVideoId">youtube id</param>
-        /// <returns></returns>
+        /// <param name="youtubeVideoId">The YouTube video ID to get the thumbnail for.</param>
+        /// <returns>The thumbnail URL string.</returns>
+        /// <exception cref="BadYoutubeIdException">
+        /// Thrown when <paramref name="youtubeVideoId"/> is not a valid YouTube video ID.
+        /// </exception>
         public static string GetYoutubeThumbnail(string youtubeVideoId) =>
-            GetYoutubeThumbnail(youtubeVideoId, YoutubeThumbnailEnum.HqDefault);
+            GetYoutubeThumbnail(youtubeVideoId, YoutubeThumbnail.HqDefault);
 
         /// <summary>
-        /// Gets the youtube thumbnail url based on the provided youtubeVideoId
+        /// Gets the thumbnail URL for the specified YouTube video at the specified quality.
         /// </summary>
-        /// <param name="youtubeVideoId"></param>
-        /// <param name="thumbnail"></param>
-        /// <returns></returns>
-        public static string GetYoutubeThumbnail(string youtubeVideoId, YoutubeThumbnailEnum thumbnail)
+        /// <param name="youtubeVideoId">The YouTube video ID.</param>
+        /// <param name="thumbnail">The desired thumbnail quality.</param>
+        /// <returns>The thumbnail URL string.</returns>
+        /// <exception cref="BadYoutubeIdException">
+        /// Thrown when <paramref name="youtubeVideoId"/> is not a valid YouTube video ID.
+        /// </exception>
+        public static string GetYoutubeThumbnail(string youtubeVideoId, YoutubeThumbnail thumbnail)
         {
             if (!IsValidYoutubeId(youtubeVideoId))
                 throw new BadYoutubeIdException(youtubeVideoId);
-            
+
             return Url.BuildAbsoluteUrl(new Uri($"https://i.ytimg.com/vi/{youtubeVideoId}/{thumbnail}.jpg"));
         }
 
         /// <summary>
-        /// Gets the youtube iframe source url based on the provided youtubeVideoId
+        /// Gets the iframe embed URL for the specified YouTube video.
         /// </summary>
-        /// <param name="youtubeVideoId"></param>
-        /// <returns></returns>
+        /// <param name="youtubeVideoId">The YouTube video ID.</param>
+        /// <returns>The embed URL string.</returns>
+        /// <exception cref="BadYoutubeIdException">
+        /// Thrown when <paramref name="youtubeVideoId"/> is not a valid YouTube video ID.
+        /// </exception>
         public static string GetYoutubeIframeUrl(string youtubeVideoId)
         {
             if (!IsValidYoutubeId(youtubeVideoId)) throw new BadYoutubeIdException(youtubeVideoId);
             return Url.BuildAbsoluteUrl(new Uri($"https://www.youtube.com/embed/{youtubeVideoId}"));
         }
 
-        
-
         /// <summary>
-        /// Checks if a youtube id matches standard youtube forms meaning:
-        /// <ul>
-        /// <li><em>CHECK 1</em> - It is not null or empty <b>AND</b></li>
-        /// <li><em>CHECK 2</em> - It is exactly 11 characters long <b>AND</b></li>
-        /// <li><em>CHECK 3</em> - It matches the pattern "[a-zA-Z0-9_-]{11}"</li>
-        /// </ul>
-        /// In that order
+        /// Determines whether a string is a valid YouTube video ID.
         /// </summary>
-        /// <param name="youtubeVideoId">The Youtube Id to match against</param>
-        /// <returns><ul>
-        /// <li><b>true</b> - If it passes all checks in order</li>
-        /// <li><b>false</b> - In all other cases</li>
-        /// </ul>
-        /// </returns>
+        /// <remarks>
+        /// Validation checks in order:
+        /// <list type="number">
+        ///   <item>Not null or empty.</item>
+        ///   <item>Exactly 11 characters long.</item>
+        ///   <item>Matches the pattern <c>^[a-zA-Z0-9_-]{11}$</c>.</item>
+        /// </list>
+        /// </remarks>
+        /// <param name="youtubeVideoId">The YouTube video ID to validate.</param>
+        /// <returns>True if the ID is valid; otherwise, false.</returns>
         public static bool IsValidYoutubeId(string? youtubeVideoId) =>
-            !string.IsNullOrEmpty(youtubeVideoId) //Not null                  AND
-            && youtubeVideoId.Length == 11 //Is 11 characters long     AND
-            && YoutubeRegex().IsMatch(youtubeVideoId); //Matches the pattern
-        
-        /// <summary>
-        /// The youtube video id matching regex pattern
-        /// </summary>
-        private const string YoutubeIdMatchPattern = "[a-zA-Z0-9_-]{11}";
-        [GeneratedRegex(YoutubeIdMatchPattern)]
-        private static partial Regex YoutubeRegex();
+            !string.IsNullOrEmpty(youtubeVideoId)
+            && youtubeVideoId.Length == 11
+            && YoutubeIdRegex().IsMatch(youtubeVideoId);
+
+        // Anchored with ^ and $ for correctness-by-construction.
+        // The Length == 11 check above provides a redundant guard, but anchoring
+        // ensures the regex is self-contained and safe if ever used independently.
+        [GeneratedRegex("^[a-zA-Z0-9_-]{11}$")]
+        private static partial Regex YoutubeIdRegex();
     }
 }

--- a/README.md
+++ b/README.md
@@ -7,421 +7,433 @@
 - **Unit Tests:** [Latest Test Results](https://github.com/friend-to-net-web-developers/micro-utilities/actions/workflows/dotnet-test-on-pr-net.yml)
 
 ## Summary
-A set of tiny utilities to help on web projects
+
+A set of small, focused utilities for .NET web projects covering email validation and normalization, URI handling, HTML ID generation, YouTube URL helpers, variable name conversion, and Unicode text analysis.
 
 ## Installation
-`Install-Package FriendToNetWebDevelopers.MicroUtilities`
 
-## Usage & Available Utilities
+```
+Install-Package FriendToNetWebDevelopers.MicroUtilities
+```
 
-For each of these, you'll need to include this.
+## Migration from 1.x
+
+Version 2.0.0 contains the following breaking changes:
+
+- **`YoutubeThumbnailEnum` renamed to `YoutubeThumbnail`** — the `Enum` suffix was misleading; this type is a smart enum (type-safe class), not a `System.Enum`.
+- **`CharacterToken.IsEmailStructural` renamed to `IsStructural`** — the old name was inaccurate; the field applies to both email and URI structural characters.
+- **`GetVariableName` and `GetClassName` now throw `ArgumentNullException` for null arguments** — previously returned `string.Empty` silently.
+- **`BuildAbsoluteUrl` logic corrected** — the port-inclusion/exclusion branches were inverted in 1.x. If you were working around this bug, remove the workaround.
+- **.NET 8 and .NET 9 support dropped** — .NET 10 is required.
+
+## Usage
+
+All utilities are accessed via the static `Utilities` class:
+
 ```csharp
 using FriendToNetWebDevelopers.MicroUtilities;
 ```
 
-### Email validation
-
-This utility attempts to validate email emails by checking for formatting and also checking a
-    list of valid top-level domains as provided by [icann.org](https://www.icann.org/resources/pages/tlds-2012-02-25-en).
-
-Testing was based on this [gist](https://gist.github.com/cjaoude/fd9910626629b53c4d25).
-However, it makes no attempt to accept the Strange Valid email addresses category.
+Extension methods require an additional using:
 
 ```csharp
-var okay = Utilities.Email.IsValidEmail("none@none.com");
-//return true
-
-okay = Utilities.Email.IsValidEmail("foo@bar");
-//returns false
+using FriendToNetWebDevelopers.MicroUtilities.Extensions;
 ```
 
-#### Email Normalization (Punycode & Unicode Support)
+---
 
-This utility allows for the normalization of email addresses based on various strategies like removing tags, trimming whitespace, and converting to lowercase. It also provides full support for Internationalized Domain Names (IDN) by converting them to Punycode.
+### Email Validation & Normalization
+
+Validates email addresses by checking format, hostname structure, and top-level domain against the [IANA TLD list](https://data.iana.org/TLD/tlds-alpha-by-domain.txt). Internationalized domain names (IDN) are fully supported via Punycode normalization.
+
+> Validation testing was based on [this gist](https://gist.github.com/cjaoude/fd9910626629b53c4d25). The "Strange Valid" category is intentionally not supported.
+
+#### Validation
 
 ```csharp
-// Default normalization (All strategies: ToLower, Trim, DropTag, DropDot)
-// Note: This method replaces the deprecated TryGetNormalizedValidEmail
-var okay = Utilities.Email.TryGetNormalizedValidPunyEmail("  First.Last+tag@München.de  ", out var punyResult, out var annotation);
+Utilities.Email.IsValidEmail("user@example.com");
+// returns true
+
+Utilities.Email.IsValidEmail("foo@bar");
+// returns false
+```
+
+> **Note on case sensitivity:** Local parts are case-sensitive per RFC 5321. `User@example.com` and `user@example.com` are technically distinct addresses. `IsValidEmail` will return `false` for an address whose local part casing differs from what the URI parser reconstructs. Normalize before validating if case-insensitive matching is required.
+
+#### Normalization (Punycode & Unicode)
+
+`TryGetNormalizedValidPunyEmail` is the primary normalization entry point. It returns both the Unicode and Punycode canonical forms of the address, along with a character-level annotation and a suspicious-input flag.
+
+```csharp
+// Default normalization — applies all strategies: ToLower, Trim, DropTag, DropDot
+var okay = Utilities.Email.TryGetNormalizedValidPunyEmail(
+    "  First.Last+tag@München.de  ",
+    out var punyResult,
+    out var annotation);
 // okay = true
-// punyResult.Unicode = "firstlast@münchen.de"
+// punyResult.Unicode  = "firstlast@münchen.de"
 // punyResult.Punycode = "firstlast@xn--mnchen-3ya.de"
 // punyResult.IsSuspicious = false
 
-// Individual strategy: Drop sub-addressing tag only
-okay = Utilities.Email.TryGetNormalizedValidPunyEmail("user+tag@example.com", TryGetNormalizedValidEmailStrategyEnum.DropTag, out punyResult, out _);
+// Drop sub-addressing tag only
+okay = Utilities.Email.TryGetNormalizedValidPunyEmail(
+    "user+tag@example.com",
+    TryGetNormalizedValidEmailStrategyEnum.DropTag,
+    out punyResult,
+    out _);
 // okay = true
 // punyResult.Unicode = "user@example.com"
 
-// Multiple strategies: Lowercase and Trim
-okay = Utilities.Email.TryGetNormalizedValidPunyEmail("  User@Example.com  ", TryGetNormalizedValidEmailStrategyEnum.LowerAndTrim, out punyResult, out _);
+// Lowercase and trim only
+okay = Utilities.Email.TryGetNormalizedValidPunyEmail(
+    "  User@Example.com  ",
+    TryGetNormalizedValidEmailStrategyEnum.LowerAndTrim,
+    out punyResult,
+    out _);
 // okay = true
 // punyResult.Unicode = "user@example.com"
 
-// Skipping internal validation (useful for custom domains or internal systems)
-okay = Utilities.Email.TryGetNormalizedValidPunyEmail("admin@internal", TryGetNormalizedValidEmailStrategyEnum.All, out punyResult, out _, skipInternalValidation: true);
+// Skip TLD validation — useful for internal/custom domains
+okay = Utilities.Email.TryGetNormalizedValidPunyEmail(
+    "admin@internal",
+    TryGetNormalizedValidEmailStrategyEnum.All,
+    out punyResult,
+    out _,
+    skipInternalValidation: true);
 // okay = true
 // punyResult.Unicode = "admin@internal"
 ```
 
+> **Provider-specific strategies:** `DropTag` (plus sub-addressing) and `DropDot` are Gmail-specific behaviours. Do not apply them when normalizing addresses for providers where `+` is not a sub-address delimiter (e.g. Fastmail, ProtonMail) or where dots are significant. Use the strategy overload and omit those flags for general-purpose normalization.
+
+Available strategy flags and pre-built combinations are defined in `TryGetNormalizedValidEmailStrategyEnum`.
+
+---
+
 ### Address Annotation & Security Analysis
 
-The `AddressAnnotator` provides deep inspection of email addresses and URIs to identify suspicious characters (like homoglyphs), Unicode usage, and invalid characters. This is particularly useful for security-sensitive applications to detect potential phishing or spoofing attempts.
+`AddressAnnotator` provides character-level inspection of email addresses and URI components, identifying suspicious characters (homoglyphs), Unicode usage, and invalid characters. Useful for detecting phishing and spoofing attempts.
 
 ```csharp
-var email = "tеst@example.com"; // Contains Cyrillic 'е' (homoglyph)
+var email = "tеst@example.com"; // Contains Cyrillic 'е' — a homoglyph of ASCII 'e'
 var annotation = Utilities.AddressAnnotator.Annotate(email);
 
-if (annotation.ContainsSuspiciousChars) 
+if (annotation.ContainsSuspiciousChars)
 {
-    // Handle potential phishing/spoofing attempt
     var suspiciousToken = annotation.LocalTokens.First(t => t.IsSuspicious);
-    // suspiciousToken.Char = "е"
+    // suspiciousToken.Char       = "е"
     // suspiciousToken.HomoglyphOf = "e"
 }
 
-// Inspect parts
-// annotation.LocalPart = "tеst"
-// annotation.Domain = "example.com"
-// annotation.ContainsUnicode = true
-// annotation.Mode = InputMode.Email
+// annotation.LocalPart           = "tеst"
+// annotation.Domain              = "example.com"
+// annotation.ContainsUnicode     = true
+// annotation.Mode                = InputMode.Email
 ```
 
-Extension methods are also available for `string`, `Uri`, and `MailAddress`:
+> **Homoglyph coverage:** The built-in table covers high-priority confusables from [Unicode TR39](https://www.unicode.org/reports/tr39/#confusables) — Cyrillic, Greek, and Latin Extended lookalikes. It is intentionally partial; extend it in your own code for broader coverage.
+
+Extension methods are available on `string`, `Uri`, and `MailAddress`:
 
 ```csharp
-using FriendToNetWebDevelopers.MicroUtilities.Extensions;
-
-var annotation = "user@example.com".Annotate();
+var annotation    = "user@example.com".Annotate(InputMode.Email);
 var uriAnnotation = new Uri("https://user:pass@example.com").AnnotateUserInfo();
 ```
 
-### Uri Utilities
+---
 
-This utility has to do with validation and generation of urls.
+### URI Utilities
 
 #### Build Absolute URL
 
-Specifically for taking the correct portions of a URI and making them build based on whether or not
-  a developer is running using localhost with a port.
+Builds an absolute URL string from a URI, automatically including or excluding the port based on whether the application is running in debug mode.
 
 ```csharp
 var urlString = Utilities.Url.BuildAbsoluteUrl(uri);
-//                 No port included ↓
-//On the server: https://example.com/some-file.jpg
-//                 Has a port                ↓
-//Debug on local machine: https://localhost:44328/some-file.jpg
+// Debug / localhost:  https://localhost:44328/some-file.jpg  (port included)
+// Production:         https://example.com/some-file.jpg      (port stripped)
 ```
 
-#### Uri Slug Generation & Validation
+#### Slug Generation & Validation
 
-Slugs are used to safely build out a url segment based on, for instance, the title of a document.
-Generating them can be somewhat tricky.  These functions serve to simplify that for the developer.
+Slugs are lowercase, hyphen-separated URL path segments. Valid slugs match `^[a-z0-9]+(?:-[a-z0-9]+)*$`.
 
-Regex for valid slug: `^[a-z0-9]+(?:-[a-z0-9]+)*$`
-
-*Validation*
 ```csharp
-Utilities.Url.IsValidUriSlug("foo-bar");
-//returns true
+// Validation
+Utilities.Url.IsValidUriSlug("foo-bar");  // true
+Utilities.Url.IsValidUriSlug("Foo Bar");  // false
 
-Utilities.Url.IsValidUriSlug("Foo Bar");
-//returns false
+// Generation
+Utilities.Url.TryToConvertToSlug("Foo Bar", out var slug);
+// returns true, slug = "foo-bar"
+
+Utilities.Url.TryToConvertToSlug("-", out var slug);
+// returns false, slug = ""
+
+Utilities.Url.TryToConvertToSlug(null, out var slug);
+// returns false, slug = ""
 ```
 
-*Generation*
+#### Username Validation
+
+Validates a userinfo component per [RFC 3986](https://www.rfc-editor.org/rfc/rfc3986).
+
 ```csharp
-var okay = Utilities.Url.TryToConvertToSlug("Foo Bar", out var slug);
-// okay = true
-// slug = "foo-bar"
-
-var okay = Utilities.Url.TryToConvertToSlug("-", out var slug);
-// okay = false
-// slug = ""
-
-var okay = Utilities.Url.TryToConvertToSlug(null, out var slug);
-// okay = false
-// slug = ""
+Utilities.Url.IsValidUsername("foobar");       // true
+Utilities.Url.IsValidUsername("foo bar");      // false
+Utilities.Url.IsValidUsername(null);           // false
+Utilities.Url.IsValidUsername(null, true);     // true — null explicitly allowed
 ```
 
-#### Uri Username Validation
-
-This is used to validate usernames for use in urls as defined by [RFC 3986](http://www.faqs.org/rfcs/rfc3986.html).
+#### Path Segment Validation
 
 ```csharp
-var okay = Utilities.Url.IsValidUsername("foobar");
-//returns true
-
-var okay = Utilities.Url.IsValidUsername("foo bar");
-//returns false
-
-var okay = Utilities.Url.IsValidUsername(null);
-//returns false
-
-var okay = Utilities.Url.IsValidUsername(null, true);
-//returns true                    because this ↑↑↑↑ allows for null values
+Utilities.Url.IsValidPathSegment("foo");      // true
+Utilities.Url.IsValidPathSegment("foo bar");  // false
+Utilities.Url.IsValidPathSegment(null);       // false
 ```
 
-#### Uri Path Segment Validation
-
-Determines whether a given string is a valid path segment.
+#### Query Parameter Name Validation
 
 ```csharp
-Utilities.Url.IsValidPathSegment("foo");
-//returns true
-
-Utilities.Url.IsValidPathSegment("foo bar");
-//returns false
-
-Utilities.Url.IsValidPathSegment(null);
-//returns false
+Utilities.Url.IsValidQueryParameterName("foo_bar");  // true
+Utilities.Url.IsValidQueryParameterName("foo@bar");  // false
 ```
 
-#### Uri Query Parameter Name Validation
+#### URL Building from a Query Object
 
-Validates whether the provided name is a valid query parameter name.
+Appends a URL-encoded query string to a base URL. Accepts either `IDictionary<string, string>` (unique keys) or `IEnumerable<KeyValuePair<string, string>>` (duplicate keys allowed, useful for array-style parameters like `ids[]=1&ids[]=2`).
 
 ```csharp
-Utilities.Url.IsValidQueryParameterName("foo_bar");
-//returns true
-
-Utilities.Url.IsValidQueryParameterName("foo@bar");
-//returns false
+var finalUrl = Utilities.Url.BuildUrl("https://api.example.com", queryObject);
 ```
 
-#### Url Building Based On A Query Object
+#### Top-Level Domain Validation
 
-Use this to take a known base url (as a string) and dynamically append a query string to it
-  based on either `IDictionary<string, string>` or `IEnumerable<KeyValuePair<string, string>>`.
-
-The dictionary is simple in that it avoid repetition.  However, the list of key value pairs can allow for multiple
- of one key.  For instance, allowing `something[]=1` and `something[]=2` which would come in
- at the server level as a list on the receiving server.
+Validates the TLD of a URI's host against the [IANA TLD list](https://data.iana.org/TLD/tlds-alpha-by-domain.txt).
 
 ```csharp
-//          This is the dictionary or enumerable object for the query ↓
-var finalUrl = Utilities.Url.BuildUrl("https://api.foobar.com", queryObject);
+Utilities.Url.HasValidTopLevelDomain(new Uri("https://foobar.com"));  // true
+Utilities.Url.HasValidTopLevelDomain(new Uri("https://foobar.web"));  // false
 ```
 
-#### Top-level Domain Validation
+#### Punycode & IDN Domain Normalization
 
-Checks if the Top-level domain within the host of the given URI is a valid domain.  Queries against the
-  text [file provided by ICANN / IANA](https://data.iana.org/TLD/tlds-alpha-by-domain.txt) for
-  the final check.
+Normalizes a domain name and produces both its Punycode and Unicode representations.
 
 ```csharp
-Utilities.Url.HasValidTopLevelDomain(new Uri("https://foobar.com"));
-//Returns true
-Utilities.Url.HasValidTopLevelDomain(new Uri("https://foobar.web"));
-//Returns false
-```
-
-#### Punycode & Internationalized Domain Normalization
-
-Attempts to normalize and convert a domain name to its Punycode and Unicode representations.
-
-```csharp
-var success = Utilities.Url.TryNormalizeAndPunycodeDomain("παράδειγμα.ελ", out var puny, out var uni);
-// success = true
+Utilities.Url.TryNormalizeAndPunycodeDomain("παράδειγμα.ελ", out var puny, out var uni);
 // puny = "xn--hxajbheg2az3al.xn--qxam"
-// uni = "παράδειγμα.ελ"
+// uni  = "παράδειγμα.ελ"
 
-success = Utilities.Url.TryNormalizeAndPunycodeDomain(" .EXAMPLE.com. ", out var puny, var out uni);
-// success = true
+Utilities.Url.TryNormalizeAndPunycodeDomain(" .EXAMPLE.com. ", out puny, out uni);
 // puny = "example.com"
-// uni = "example.com"
+// uni  = "example.com"
 ```
+
+---
 
 ### ID Utilities
 
-The ID utilities are meant to quickly get, validate, and return valid id attributes.
+Generates, validates, and coerces valid HTML `id` attribute values. Useful when multiple dynamic elements on a page (accordions, sliders, tabs) need stable, unique IDs that reference each other.
 
-#### Generate IDs
+#### Generation
 
-This is used when creating elements which need to refer to each other by id but there can be many
-on the page at the same time (accordion elements, sliders, etc).
+A prefix is required (defaults to `"id"`). An optional suffix may also be supplied. Supported base types: `Guid`, `int`, `uint`, `long`, `ulong`.
 
-A prefix is required and included by default.  You can change what the prefix is by adding it in. As suffix may also be included.
-
-```C#
-//Generates a valid id attribute value based on a guid with a prefix of "id"
-//example: Returns id02bfd4e04f0b43f9bf407d3162db9289 (generated from new Guid)
+```csharp
+// From a new Guid — returns e.g. "id02bfd4e04f0b43f9bf407d3162db9289"
 Utilities.Id.GetValidHtmlId();
 
-//Formats various types of data into a valid id value
-// types include Guid, int, uint, long, ulong
-// also includes:             |    prefix   suffix
-//                            ↓       ↓        ↓                 
+// From a numeric value with custom prefix and suffix
 Utilities.Id.GetValidHtmlId(4444, "foo_", "_bar");
-// ↑ Returns "foo_4444_bar"
+// returns "foo_4444_bar"
 ```
 
-#### Validate IDs
-This utility can also be used to validate IDs which can be specified in an unsafe way (user input).
-```C#
-string? nullId = null;
-Utilities.Id.IsValidId(nullId);
-// ↑ Returns false
+#### Validation
 
-Utilities.Id.IsValidId("bob dole");
-// ↑ Returns false
-
-Utilities.ID.IsValidId("bob_dole");
-// ↑ Returns true
+```csharp
+Utilities.Id.IsValidId(null);       // false
+Utilities.Id.IsValidId("bob dole"); // false
+Utilities.Id.IsValidId("bob_dole"); // true
 ```
 
-It can also parse an unsafe, nullable proposed id value and ensure a non-nullable string is output.
-```C#
-Utilities.Id.TryGetAsValidId("bob dole", TryGetValidIdDefaultStrategyEnum.EmptyOnInvalid, var out thisWillBeEmpty);
-// ↑ Returns false | thisWilBeEmpty will return string.Empty - this is so that other transformations can be handled
+Single-letter IDs are valid:
 
-Utilities.Id.TryGetAsValidId("foo bar", TryGetValidIdDefaultStrategyEnum.GenerateOnInvalid, var out thisWillBeAGeneratedId);
-// ↑ Returns false | thisWillBeAGeneratedId will return default value from GetValidHtmlId()
-
-Utilities.Id.TryGetAsValidId("foo_bar_baz", TryGetValidIdDefaultStrategyEnum.GenerateOnInvalid, var out thisWillBeFooBarBaz);
-// ↑ Returns true | thisWillBeFooBarBaz will be "foo_bar_baz"
+```csharp
+Utilities.Id.IsValidId("a"); // true
 ```
 
-### Youtube Utilities
+#### Coercion with Fallback
+
+Returns a guaranteed non-null string using a fallback strategy when the input is invalid:
+
+```csharp
+Utilities.Id.TryGetAsValidId(
+    "bob dole",
+    TryGetValidIdDefaultStrategyEnum.EmptyOnInvalid,
+    out var result);
+// returns false, result = ""
+
+Utilities.Id.TryGetAsValidId(
+    "foo bar",
+    TryGetValidIdDefaultStrategyEnum.GenerateOnInvalid,
+    out result);
+// returns false, result = generated id from GetValidHtmlId()
+
+Utilities.Id.TryGetAsValidId(
+    "foo_bar_baz",
+    TryGetValidIdDefaultStrategyEnum.GenerateOnInvalid,
+    out result);
+// returns true, result = "foo_bar_baz"
+```
+
+---
+
+### YouTube Utilities
 
 #### ID Validation
 
-Checks if the given ID is valid based on matching the regex pattern: `[a-zA-Z0-9_-]{11}`
+Checks that a string is a valid YouTube video ID — exactly 11 characters matching `^[a-zA-Z0-9_-]{11}$`.
 
 ```csharp
-Utilities.Youtube.IsValidYoutubeId("SrN4A9rVXj0");
-// ↑ Returns true
-Utilities.Youtube.IsValidYoutubeId("foo-bar");
-// ↑ Returns false
+Utilities.Youtube.IsValidYoutubeId("SrN4A9rVXj0");  // true
+Utilities.Youtube.IsValidYoutubeId("foo-bar");       // false
 ```
 
-#### Thumbnail
-Retrieves the thumbnail for the given youtube id.
+#### Thumbnail URLs
 
 ```csharp
-var thumbnailUrl = Utilities.Youtube.GetYoutubeThumbnail("SrN4A9rVXj0");
-//Returns "https://i.ytimg.com/vi/SrN4A9rVXj0/hqdefault.jpg"
-thumbnailUrl = Utilities.Youtube.GetYoutubeThumbnail("SrN4A9rVXj0", YoutubeThumbnailEnum.MaxResDefault);
-//Returns "https://i.ytimg.com/vi/SrN4A9rVXj0/maxresdefault.jpg"
-thumbnailUrl = Utilities.Youtube.GetYoutubeThumbnail("foo-bar", YoutubeThumbnailEnum.MaxResDefault);
-//Throws BadYoutubeIdException
+// HQ default thumbnail (always available)
+Utilities.Youtube.GetYoutubeThumbnail("SrN4A9rVXj0");
+// returns "https://i.ytimg.com/vi/SrN4A9rVXj0/hqdefault.jpg"
+
+// Max resolution thumbnail (may not be available for all videos)
+Utilities.Youtube.GetYoutubeThumbnail("SrN4A9rVXj0", YoutubeThumbnail.MaxResDefault);
+// returns "https://i.ytimg.com/vi/SrN4A9rVXj0/maxresdefault.jpg"
+
+// Invalid ID throws
+Utilities.Youtube.GetYoutubeThumbnail("foo-bar", YoutubeThumbnail.MaxResDefault);
+// throws BadYoutubeIdException
 ```
 
-#### Embed
-
-Retrieves the url for embedding youtube on a page.
+#### Embed URL
 
 ```csharp
 Utilities.Youtube.GetYoutubeIframeUrl("SrN4A9rVXj0");
-//Returns https://www.youtube.com/embed/SrN4A9rVXj0
+// returns "https://www.youtube.com/embed/SrN4A9rVXj0"
+
 Utilities.Youtube.GetYoutubeIframeUrl("foo-bar");
-//Throws BadYoutubeIdException
+// throws BadYoutubeIdException
 ```
+
+---
 
 ### Variable & Class Naming Utilities
 
-This utility provides methods to identify, convert, and generate variable and class names according to various naming conventions.
+Identifies, converts, and generates variable and class names across naming conventions.
+
+Supported conventions: `CamelCase`, `PascalCase`, `SnakeCase`, `ScreamingSnakeCase`, `KebabCase`, `TrainCase`, `Unicase`, `TrollCase`, `TitleWords`, `SentenceWords`.
+
+> **Acronym casing:** When converting to mixed-case formats, word tails are lowercased. `HTMLParser` → `HtmlParser` (PascalCase) or `htmlParser` (camelCase). This is consistent with common .NET conventions (`HtmlEncoder`, `JsonSerializer`) and is intentional.
+
+> **Unicase / TrollCase inputs:** Word boundaries cannot be recovered from all-lower or all-upper input. Such inputs are treated as a single word when converting to other formats.
 
 #### Format Detection
-Identify the naming convention of a given string. Supported types include `CamelCase`, `PascalCase`, `SnakeCase`, `ScreamingSnakeCase`, `KebabCase`, `TrainCase`, `Unicase`, and `TrollCase`.
 
 ```csharp
-var type = Utilities.Variable.GetVariableFormat("snake_case_example");
+Utilities.Variable.GetVariableFormat("snake_case_example");
 // returns ResultsVariableNameTypeEnum.SnakeCase
 
-var isCamel = "camelCase".IsVariableName(ResultsVariableNameTypeEnum.CamelCase);
+"camelCase".IsVariableName(ResultsVariableNameTypeEnum.CamelCase);
 // returns true
 ```
 
-#### Conversion & "Forced" Formatting
-Convert between naming conventions. If a string doesn't follow a strict convention (e.g., has spaces or special characters), it is identified as `Words` and can still be converted.
+#### Conversion
 
 ```csharp
-// Convert to PascalCase
-var pascal = Utilities.Variable.ConvertToPascalCase("hello-world").result;
+Utilities.Variable.ConvertToPascalCase("hello-world").result;
 // returns "HelloWorld"
 
-// Force conversion from a sentence
-var camel = "This is a test".ConvertTo(RequestedVariableNameTypeEnum.CamelCase).result;
+"This is a test".ConvertTo(RequestedVariableNameTypeEnum.CamelCase).result;
 // returns "thisIsATest"
 
-// Title Case (follows standard English rules for minor words)
-var title = Utilities.Variable.ConvertToTitleWords("a tale of two cities").result;
+Utilities.Variable.ConvertToTitleWords("a tale of two cities").result;
 // returns "A Tale of Two Cities"
 
-// Sentence Case
-var sentence = Utilities.Variable.ConvertToSentenceWords("snake_case_variable").result;
+Utilities.Variable.ConvertToSentenceWords("snake_case_variable").result;
 // returns "Snake case variable"
 ```
 
-#### Naming from Metadata
-Generate variable or class names directly from objects, types, or reflection metadata.
+#### Naming from Reflection Metadata
 
 ```csharp
 var myInstance = new MyCustomClass();
 
-// To variable name (camelCase by default)
-string varName = myInstance.ToVariableName(); 
+myInstance.ToVariableName();
 // returns "myCustomClass"
 
-// To class name (PascalCase)
-string className = typeof(MyCustomClass).ToClassName();
+typeof(MyCustomClass).ToClassName();
 // returns "MyCustomClass"
 
-// Handles generic types (strips arity)
-string listName = typeof(List<int>).ToVariableName();
-// returns "list"
+typeof(List<int>).ToVariableName();
+// returns "list"  (generic arity suffix stripped)
 ```
+
+> `GetVariableName` and `GetClassName` throw `ArgumentNullException` for null arguments.
+
+---
 
 ### Text & Unicode Utilities
 
-Provides advanced character-level analysis and Unicode-safe encoding/decoding. These utilities are particularly useful for handling internationalized text, surrogate pairs, and for security/sanitization tasks.
+Character-level analysis and Unicode-safe encoding/decoding. Handles surrogate pairs (supplementary plane characters such as emoji) correctly as single units.
 
 #### Unicode Escape Encoding & Decoding
 
-Convert between readable Unicode characters and ASCII-compatible escape sequences (`\uXXXX` for BMP, `\UXXXXXXXX` for supplementary planes).
+Converts between Unicode characters and ASCII-compatible escape sequences (`\uXXXX` for BMP characters, `\UXXXXXXXX` for supplementary plane characters).
 
 ```csharp
-// Encode to escaped ASCII
-var escaped = Utilities.Text.EncodeUnicodeEscapes("A©😀");
+Utilities.Text.EncodeUnicodeEscapes("A©😀");
 // returns "A\u00A9\U0001F600"
 
-// Decode back to Unicode
-var decoded = Utilities.Text.DecodeUnicodeEscapes("A\\u00A9\\U0001F600");
+Utilities.Text.DecodeUnicodeEscapes("A\\u00A9\\U0001F600");
 // returns "A©😀"
 
 // Extension methods
-var extEscaped = "A©😀".ToUnicodeEscapedAscii();
-var extDecoded = "A\\u00A9\\U0001F600".ToUnicodeDecoded();
+"A©😀".ToUnicodeEscapedAscii();
+"A\\u00A9\\U0001F600".ToUnicodeDecoded();
 ```
 
 #### Text Character Annotation
 
-The `TextAnnotator` provides character-by-character analysis, correctly handling surrogate pairs (e.g., emojis) as single units. It classifies characters into types like `Letter`, `Digit`, `Whitespace`, `Special`, and `Unicode`.
+Tokenizes a string character-by-character, classifying each as `Letter`, `Digit`, `Whitespace`, `Special`, or `Unicode`, with code point and escape sequence metadata.
 
 ```csharp
-var text = "A 😀 1";
-var tokens = text.Annotate().ToList();
+var tokens = "A 😀 1".Annotate().ToList();
 
-// tokens[0]: "A", Type: Letter, Index: 0
-// tokens[1]: " ", Type: Whitespace, Index: 1
-// tokens[2]: "😀", Type: Unicode, Index: 2, CodePoint: 0x1F600, UnicodeEscape: "\U0001F600"
-// tokens[3]: " ", Type: Whitespace, Index: 4 (Index jumped past surrogate pair)
-// tokens[4]: "1", Type: Digit, Index: 5
+// tokens[0]: "A",  Type: Letter,     Index: 0
+// tokens[1]: " ",  Type: Whitespace,  Index: 1
+// tokens[2]: "😀", Type: Unicode,     Index: 2, CodePoint: 0x1F600, UnicodeEscape: "\U0001F600"
+// tokens[3]: " ",  Type: Whitespace,  Index: 4  (index advanced past surrogate pair)
+// tokens[4]: "1",  Type: Digit,       Index: 5
 ```
+
+---
 
 ## Notes & Compatibility
 
 ### .NET Version Support
-This library supports .NET 8, .NET 9, and .NET 10. 
-Please note that support for **.NET 8** and **.NET 9** is planned to be dropped in the future as they reach their end-of-life. We recommend migrating to **.NET 10** or newer for continued support and security updates.
+
+This library targets **.NET 10** only. Earlier versions are not supported.
 
 ### Thread Safety
-All utility functions in this library are static and designed to be thread-safe. They do not maintain internal state that could lead to race conditions.
+
+All utility methods are static and stateless. The library is thread-safe.
 
 ### Performance
-Many of these utilities use `GeneratedRegex` for optimal performance.
+
+Regex-heavy paths use `[GeneratedRegex]` for compile-time source generation. `TitleCaseMinorWords` lookups use `HashSet<string>` for O(1) access.
 
 ### TLD Updates
-The `HasValidTopLevelDomain` and `IsValidEmail` functions rely on a list of TLDs provided by ICANN/IANA. This list is updated periodically within the library to ensure accuracy.
 
+`HasValidTopLevelDomain` and `IsValidEmail` validate against the IANA TLD list bundled with the library. This list is updated periodically with new releases.

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "10.0.0",
+    "rollForward": "latestMajor",
+    "allowPrerelease": true
+  }
+}


### PR DESCRIPTION
## 2.0.0 Release

This PR brings the 2.0.0 release into `main`. It contains a substantial set of bug fixes, correctness improvements, and breaking changes accumulated during an in-depth review of the full library.

---

## Breaking Changes

### `YoutubeThumbnailEnum` renamed to `YoutubeThumbnail`
The `Enum` suffix implied a `System.Enum`. This type is a smart enum (type-safe class) and has been renamed accordingly.

### `CharacterToken.IsEmailStructural` renamed to `IsStructural`
The old name was inaccurate — the field applies to both email and URI structural characters, not email only.

### `GetVariableName` and `GetClassName` now throw `ArgumentNullException` for null arguments
Previously returned `string.Empty` silently. Null arguments are now treated as a caller error, consistent with standard .NET behaviour.

### .NET 8 and .NET 9 support dropped
.NET 10 is required. Both dropped versions reach EOL in 2025/2026.

---

## Bug Fixes

### `BuildAbsoluteUrl` — port inclusion logic was inverted
The debug and production branches were swapped. In 1.x, production URLs included the port and debug URLs stripped it — the opposite of the intended and documented behaviour. Corrected.

### `EmailUsernameRegex` — consecutive separators incorrectly accepted
The regex allowed consecutive separator characters (`.`, `-`, `+`) in the local part, causing addresses like `email..email@example.com` to pass validation. Prohibited by RFC 5321 §4.1.2. Pattern restructured so any separator must be followed by at least one alphanumeric character or underscore:
```
// Before
^[a-z0-9_]([.\-+a-z0-9_]*[a-z0-9_])?$

// After
^[a-z0-9_]+([.\-+][a-z0-9_]+)*$
```

### `PunyUniResult.From` — `PlainAscii` domains not structurally validated
Plain ASCII domains bypassed `IdnMapping.GetAscii` entirely, meaning structurally invalid inputs like `"not a domain!"` would produce a result with `IsSuspicious = false`. All domain forms now pass through `GetAscii` for structural validation regardless of encoding.

### `PunyUniResult.From` — bare `catch` replaced
Now catches `ArgumentException` specifically, which is what `IdnMapping` throws for malformed input. Unexpected exceptions no longer get swallowed as `Invalid` results.

### `TryNormalizeAndPunycodeDomain` — bare catches replaced
Same pattern as above. Both `catch` blocks now catch `ArgumentException` specifically.

### `BuildUrl` — `%5b%5d` bracket restoration was case-sensitive
`HttpUtility.UrlEncode` may produce either `%5b%5d` or `%5B%5D` depending on runtime. The replacement is now case-insensitive.

### `PascalSplitRegex` — consecutive uppercase runs split incorrectly
The old pattern `(?=[A-Z])` split `HTMLParser` into `["H","T","M","L","Parser"]` instead of `["HTML","Parser"]`. Replaced with a two-condition lookahead/lookbehind pattern that correctly keeps acronym runs together:
```
(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])
```

### `AddressAnnotator` — `+` in `EmailSpecialChars` was dead data
`+` is caught as `EmailStructural` before the `HashSet` is consulted in email mode. Removed and documented.

### `Punycode` label detection — `xn--` check was case-sensitive
`StartsWith("xn--")` would misclassify `XN--` labels as `PlainAscii`. Now uses `StringComparison.OrdinalIgnoreCase`.

---

## Improvements

### `IsSameFormat` replaces string-based cross-enum comparison
The old `from.ToString() == targetType.ToString()` comparison across `ResultsVariableNameTypeEnum` and `RequestedVariableNameTypeEnum` was one rename away from a silent bug. Replaced with an explicit switch expression mapping each value.

### `TitleCaseMinorWords` — `string[]` replaced with `HashSet<string>`
Lookup is now O(1) with `StringComparer.OrdinalIgnoreCase`, removing the need for a `.ToLower()` call at the lookup site.

### `IdUtilities` — `DefaultPrefix` short-circuit removed
The `_isValidIdPrefix` method short-circuited on `DefaultPrefix` before the regex, implying `"id"` was special-cased for a reason. It matches the regex just fine. Short-circuit removed.

### `IdUtilities` — prefix trimming made consistent
The `long` and `ulong` overloads trimmed the prefix silently; the others did not. Whitespace in a prefix is now treated as a caller error and rejected by validation rather than trimmed silently across all overloads.

### `HtmlIdValueInternalRegex` — single-character IDs now valid
The old pattern required at least two characters. The optional group `([a-zA-Z0-9_\-]*[a-zA-Z0-9])?` now makes the middle+end section optional, correctly accepting single-letter IDs like `"a"`.

### Private method naming convention
Private static methods across `AddressAnnotator` and `IdUtilities` renamed from `_camelCase` to `PascalCase`, consistent with .NET idioms.

### `strategy.HasFlag()` replaces manual bitwise checks
All `((int)strategy & (int)...) != 0` checks in `EmailUtilities` replaced with `strategy.HasFlag(...)` for clarity.

### `TryConvertTo` bare catch narrowed
Now catches `ArgumentException` specifically rather than swallowing all exceptions silently.

---

## Documentation

- README rewritten for 2.0.0 with a migration guide, corrected examples throughout, and notes on provider-specific email strategy behaviour, acronym casing, and homoglyph table coverage
- XML docs expanded across all public methods and types, including `<exception>` tags, RFC references, and explicit documentation of non-obvious behaviour
- `TryGetValidIdDefaultStrategyEnum` XML docs added — the only enum in the library that previously had none
- `YoutubeThumbnail` (formerly `YoutubeThumbnailEnum`) documented as a smart enum with an explanation of the pattern

---

## References

- RFC 5321 §4.1.2 — local part syntax
- RFC 3986 — URI userinfo
- [Unicode TR39 confusables](https://www.unicode.org/reports/tr39/#confusables)
- [Email test reference gist](https://gist.github.com/cjaoude/fd9910626629b53c4d25)